### PR TITLE
[FEAT/#48] Candidate Pog 연결

### DIFF
--- a/core/model/src/commonMain/kotlin/every/lol/com/core/model/MatchPogCandidate.kt
+++ b/core/model/src/commonMain/kotlin/every/lol/com/core/model/MatchPogCandidate.kt
@@ -1,8 +1,8 @@
 package every.lol.com.core.model
 
 data class MatchPogCandidate(
-    val matchId: Int,
+    val matchId: Long,
     val winnerTeamName: String,
     val candidates: List<PogCandidateCandidate>,
-    val myVotedPlayerId: Int
+    val myVotedPlayerId: Long? = null
 )

--- a/core/model/src/commonMain/kotlin/every/lol/com/core/model/SetPogCandidate.kt
+++ b/core/model/src/commonMain/kotlin/every/lol/com/core/model/SetPogCandidate.kt
@@ -8,7 +8,7 @@ data class SetPogCandidateDetail(
     val setIndex: Int,
     val winnerTeamName: String,
     val candidates: List<PogCandidateCandidate>,
-    val myVotedPlayerId: Int
+    val myVotedPlayerId: Long? = null
 )
 
 data class PogCandidateCandidate(

--- a/core/network/src/commonMain/kotlin/every/lol/com/core/network/model/response/MatchPogCandidateResponse.kt
+++ b/core/network/src/commonMain/kotlin/every/lol/com/core/network/model/response/MatchPogCandidateResponse.kt
@@ -4,8 +4,8 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class MatchPogCandidateResponse(
-    val matchId: Int,
+    val matchId: Long,
     val winnerTeamName: String,
     val candidates: List<PogCandidateCandidateResponse>,
-    val myVotedPlayerId: Int
+    val myVotedPlayerId: Long ? = null
 )

--- a/core/network/src/commonMain/kotlin/every/lol/com/core/network/model/response/SetPogCandidateResponse.kt
+++ b/core/network/src/commonMain/kotlin/every/lol/com/core/network/model/response/SetPogCandidateResponse.kt
@@ -12,7 +12,7 @@ data class SetPogCandidateDetailResponse(
     val setIndex: Int,
     val winnerTeamName: String,
     val candidates: List<PogCandidateCandidateResponse>,
-    val myVotedPlayerId: Int
+    val myVotedPlayerId: Long ? = null
 )
 
 @Serializable

--- a/feature/matches/src/commonMain/kotlin/every/lol/com/feature/matches/MatchesViewModel.kt
+++ b/feature/matches/src/commonMain/kotlin/every/lol/com/feature/matches/MatchesViewModel.kt
@@ -39,7 +39,11 @@ class MatchesViewModel(
                 loadMatches()
             }
 
-            is MatchIntent.ClickPrediction -> getMatchCandidate(intent.matchId)
+            is MatchIntent.ClickPrediction -> {
+                getMatchCandidate(intent.matchId)
+                getMatchPogCandidate(intent.matchId)
+                getSetPogCandidate(intent.matchId)
+            }
 
             is MatchIntent.ClickLiveResult -> {
                 _uiState.value = MatchUiState.LiveResult(
@@ -82,6 +86,7 @@ class MatchesViewModel(
             }
         }
     }
+
     private fun loadMatches() {
         viewModelScope.launch {
             _uiState.value = MatchUiState.Loading
@@ -141,13 +146,13 @@ class MatchesViewModel(
     }
 
 
-
     //승혁 코드
-    private fun getMatchCandidate(matchId: Long){
+    private fun getMatchCandidate(matchId: Long) {
         viewModelScope.launch {
             getMatchCandidateUseCase(matchId).onSuccess {
                 _uiState.update { state ->
-                    val currentState = state as? MatchUiState.Prediction ?: MatchUiState.Prediction()
+                    val currentState =
+                        state as? MatchUiState.Prediction ?: MatchUiState.Prediction()
                     currentState.copy(
                         isLoading = false,
                         matchId = it.matchId
@@ -155,12 +160,59 @@ class MatchesViewModel(
                 }
             }.onFailure { error ->
                 _uiState.update { state ->
-                    val currentState = state as? MatchUiState.Prediction ?: MatchUiState.Prediction()
+                    val currentState =
+                        state as? MatchUiState.Prediction ?: MatchUiState.Prediction()
                     currentState.copy(isLoading = false)
-                    }
+                }
                 println(error)
                 //_event.emit(MatchEvent.ShowToast(error.message ?: "데이터를 불러오지 못했습니다."))
             }
         }
     }
+
+    private fun getMatchPogCandidate(matchId: Long) {
+        viewModelScope.launch {
+            getMatchPogCandidateUseCase(matchId).onSuccess {
+                _uiState.update { state ->
+                    val currentState =
+                        state as? MatchUiState.Prediction ?: MatchUiState.Prediction()
+                    currentState.copy(
+                        isLoading = false,
+                        matchId = it.matchId
+                    )
+                }
+            }.onFailure { error ->
+                _uiState.update { state ->
+                    val currentState =
+                        state as? MatchUiState.Prediction ?: MatchUiState.Prediction()
+                    currentState.copy(isLoading = false)
+                }
+                println(error)
+            }
+        }
+    }
+
+    private fun getSetPogCandidate(matchId: Long) {
+        viewModelScope.launch {
+            getSetPogCandidateUseCase(matchId).onSuccess {
+                _uiState.update { state ->
+                    val currentState =
+                        state as? MatchUiState.Prediction ?: MatchUiState.Prediction()
+                    currentState.copy(
+                        isLoading = false,
+                        setId = it.sets
+                    )
+                }
+            }.onFailure { error ->
+                _uiState.update { state ->
+                    val currentState =
+                        state as? MatchUiState.Prediction ?: MatchUiState.Prediction()
+                    currentState.copy(isLoading = false)
+                }
+                println(error)
+            }
+        }
+    }
+
+
 }

--- a/feature/matches/src/commonMain/kotlin/every/lol/com/feature/matches/model/MatchUiState.kt
+++ b/feature/matches/src/commonMain/kotlin/every/lol/com/feature/matches/model/MatchUiState.kt
@@ -1,6 +1,7 @@
 package every.lol.com.feature.matches.model
 
 import every.lol.com.core.model.MatchCardModel
+import every.lol.com.core.model.SetPogCandidateDetail
 
 sealed interface MatchUiState {
     data class Matches(
@@ -10,7 +11,8 @@ sealed interface MatchUiState {
 
     data class Prediction(
         val isLoading: Boolean = false,
-        val matchId: Long = 0
+        val matchId: Long = 0,
+        val setId: List<SetPogCandidateDetail>? = null
     ) : MatchUiState
 
     data class LiveResult(


### PR DESCRIPTION
- closed #48 

## 📝작업 내용
> 세트 및 매치 POG 후보군을 불러오는 API 연동 및 데이터 레이어 작업 완료

- setPog, matchPog 후보군 조회를 위한 서비스 및 레포지토리 구현
- 후보 선수들의 프로필 및 스탯 데이터를 포함한 DTO 구성
- UI 레이어 전달을 위한 도메인 모델 매퍼 작성

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
> 두 종류의 POG 후보군 조회 시 중복되는 로직을 효과적으로 분리했는지 검토 요청

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 예측 기능에서 세트별 최고 성능 후보자 정보 추가 표시

* **개선**
  * 투표 데이터 누락 시 안정성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->