### PR TITLE
[FEAT/#73] community UI 수정

### DIFF
--- a/core/designsystem/src/commonMain/kotlin/every/lol/com/core/designsystem/component/EverylolToast.kt
+++ b/core/designsystem/src/commonMain/kotlin/every/lol/com/core/designsystem/component/EverylolToast.kt
@@ -1,0 +1,58 @@
+package every.lol.com.core.designsystem.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.unit.dp
+import every.lol.com.core.designsystem.theme.EveryLoLTheme
+
+@Composable
+fun EverylolToast (
+    text: String,
+    modifier : Modifier = Modifier
+){
+    val borderColor = EveryLoLTheme.color.grayScale800
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 28.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .background(EveryLoLTheme.color.grayScale1000.copy(0.8f))
+            .drawWithContent {
+                drawContent()
+                val strokeWidth = 1.dp.toPx()
+                val halfStrokeWidth = strokeWidth / 2
+
+                drawRoundRect(
+                    color = borderColor,
+                    topLeft = Offset(halfStrokeWidth, halfStrokeWidth),
+                    size = Size(
+                        size.width - strokeWidth,
+                        size.height - strokeWidth
+                    ),
+                    cornerRadius = CornerRadius(8.dp.toPx()),
+                    style = Stroke(width = strokeWidth)
+                )
+            }
+            .padding(24.dp, 12.dp),
+        contentAlignment = Alignment.CenterStart
+    ){
+        Text(
+            text = text,
+            style = EveryLoLTheme.typography.pretendardBody01,
+            color = EveryLoLTheme.color.white200
+        )
+    }
+}

--- a/core/designsystem/src/commonMain/kotlin/every/lol/com/core/designsystem/component/EverylolToast.kt
+++ b/core/designsystem/src/commonMain/kotlin/every/lol/com/core/designsystem/component/EverylolToast.kt
@@ -3,8 +3,11 @@ package every.lol.com.core.designsystem.component
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -19,6 +22,13 @@ import androidx.compose.ui.unit.dp
 import every.lol.com.core.designsystem.theme.EveryLoLTheme
 
 @Composable
+fun EverylolToastHost(hostState: SnackbarHostState, modifier: Modifier = Modifier) {
+    SnackbarHost(hostState = hostState, modifier = modifier.padding(bottom = 80.dp) ) { data ->
+        EverylolToast(text = data.visuals.message)
+    }
+}
+
+@Composable
 fun EverylolToast (
     text: String,
     modifier : Modifier = Modifier
@@ -27,6 +37,7 @@ fun EverylolToast (
     Box(
         modifier = modifier
             .fillMaxWidth()
+            .heightIn(max = 120.dp)
             .padding(horizontal = 28.dp)
             .clip(RoundedCornerShape(8.dp))
             .background(EveryLoLTheme.color.grayScale1000.copy(0.8f))

--- a/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/CommunityViewModel.kt
+++ b/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/CommunityViewModel.kt
@@ -338,9 +338,11 @@ class CommunityViewModel(
                     onIntent(CommunityIntent.Loading)
                 }.onFailure { e ->
                     _uiState.update { if (it is CommunityUiState.Write) it.copy(isLoading = false) else it }
+                    _event.emit(CommunityEvent.ShowToast("업로드에 실패했습니다: ${e.message}"))
                 }
             } catch (e: Exception) {
                 _uiState.update { if (it is CommunityUiState.Write) it.copy(isLoading = false) else it }
+                _event.emit(CommunityEvent.ShowToast("업로드에 실패했습니다: ${e.message}"))
             }
         }
     }

--- a/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/CommunityViewModel.kt
+++ b/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/CommunityViewModel.kt
@@ -411,8 +411,13 @@ class CommunityViewModel(
     private fun handleLikePost(postId: Int){
         viewModelScope.launch {
             postCommunityPostLikeUseCase(postId).onSuccess { response ->
-                _uiState.update {
-                    if (it is CommunityUiState.Read) it.copy(isLiked = !response.isLiked, likeCount = response.likeCount) else it
+                _uiState.update { state ->
+                    if (state is CommunityUiState.Read && state.postId == postId) {
+                        state.copy(
+                            isLiked = response.isLiked,
+                            likeCount = response.likeCount
+                        )
+                    } else state
                 }
             }.onFailure {
                 _event.emit(CommunityEvent.ShowToast("좋아요에 실패하였습니다."))

--- a/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/ReadCommunityScreen.kt
+++ b/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/ReadCommunityScreen.kt
@@ -103,7 +103,9 @@ fun ReadRoute(
             postId = postId,
             state = currentState,
             onBackClick = onBackClick,
-            onIntent = viewModel::onIntent
+            onIntent = viewModel::onIntent,
+            isLiked = currentState.isLiked,
+            likeCount = currentState.likeCount
         )
     } else {
         Box(
@@ -129,7 +131,9 @@ fun ReadCommunityScreen(
     postId: Int,
     state: CommunityUiState.Read,
     onBackClick: () -> Unit,
-    onIntent: (CommunityIntent) -> Unit
+    onIntent: (CommunityIntent) -> Unit,
+    isLiked: Boolean = false,
+    likeCount: Int = 0
 ) {
 
     val snackbarHostState = remember { SnackbarHostState() }
@@ -244,6 +248,9 @@ fun ReadCommunityScreen(
             }
         ) { innerPadding ->
             state.post?.let { postDetail ->
+                val safeCommentList = postDetail.commentList ?: emptyList()
+                val isCommented = safeCommentList.any { it.isWriter }
+
                 PullToRefreshBox(
                     state = pullToRefreshState,
                     isRefreshing = isRefreshing,
@@ -279,7 +286,10 @@ fun ReadCommunityScreen(
                                 onMoreClick = { isPostMenuExpanded = true },
                                 onImageClick = { url -> selectedMedia = url to false },
                                 onVideoClick = { url -> selectedMedia = url to true },
-                                onLikeClick = { onIntent(CommunityIntent.LikePost(postId)) }
+                                onLikeClick = { onIntent(CommunityIntent.LikePost(postId)) },
+                                isCommented = isCommented,
+                                isLiked = isLiked,
+                                likeCount = likeCount
                             )
                         }
 

--- a/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/ReadCommunityScreen.kt
+++ b/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/ReadCommunityScreen.kt
@@ -244,9 +244,6 @@ fun ReadCommunityScreen(
             }
         ) { innerPadding ->
             state.post?.let { postDetail ->
-                val safeCommentList = postDetail.commentList ?: emptyList()
-                val isCommented = safeCommentList.any { it.isWriter }
-
                 PullToRefreshBox(
                     state = pullToRefreshState,
                     isRefreshing = isRefreshing,
@@ -282,10 +279,7 @@ fun ReadCommunityScreen(
                                 onMoreClick = { isPostMenuExpanded = true },
                                 onImageClick = { url -> selectedMedia = url to false },
                                 onVideoClick = { url -> selectedMedia = url to true },
-                                onLikeClick = { onIntent(CommunityIntent.LikePost(postId)) },
-                                isCommented = isCommented,
-                                isLiked = state.isLiked,
-                                likeCount = state.likeCount
+                                onLikeClick = { onIntent(CommunityIntent.LikePost(postId)) }
                             )
                         }
 

--- a/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/WirteCommunityScreen.kt
+++ b/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/WirteCommunityScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -39,6 +38,7 @@ import every.lol.com.core.common.rememberPlatformContext
 import every.lol.com.core.designsystem.component.EverylolButton
 import every.lol.com.core.designsystem.component.EverylolModal
 import every.lol.com.core.designsystem.component.EverylolTextField
+import every.lol.com.core.designsystem.component.EverylolToastHost
 import every.lol.com.core.designsystem.component.EverylolTopAppBar
 import every.lol.com.core.designsystem.theme.EveryLoLTheme
 import every.lol.com.core.ui.ext.everylolDefault
@@ -63,6 +63,7 @@ fun WriteRoute(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val currentState = uiState
     val focusManager = LocalFocusManager.current
+    val snackbarHostState = remember { SnackbarHostState() }
 
     LaunchedEffect(Unit) {
         if (uiState !is CommunityUiState.Write) {
@@ -77,6 +78,9 @@ fun WriteRoute(
                     focusManager.clearFocus()
                     onBackClick()
                 }
+                is CommunityEvent.ShowToast -> {
+                    snackbarHostState.showSnackbar(event.message)
+                }
                 else -> {}
             }
         }
@@ -87,7 +91,8 @@ fun WriteRoute(
             WriteCommunityScreen(
                 state = currentState,
                 onBackClick = onBackClick,
-                onIntent = viewModel::onIntent
+                onIntent = viewModel::onIntent,
+                snackbarHostState = snackbarHostState
             )
         }
     }
@@ -97,11 +102,11 @@ fun WriteRoute(
 fun WriteCommunityScreen(
     state: CommunityUiState.Write,
     onBackClick: () -> Unit,
-    onIntent: (CommunityIntent) -> Unit
+    onIntent: (CommunityIntent) -> Unit,
+    snackbarHostState: SnackbarHostState
 ) {
 
     val scope = rememberCoroutineScope()
-    val snackbarHostState = remember { SnackbarHostState() }
     val isFormValid = state.title.isNotBlank() && state.content.isNotBlank()
     var showWritePostModal by remember { mutableStateOf(false) }
     val keyboardHeight = WindowInsets.ime.getBottom(LocalDensity.current)
@@ -163,7 +168,7 @@ fun WriteCommunityScreen(
                 .everylolDefault(EveryLoLTheme.color.newBg, false),
             containerColor = Color.Transparent,
             contentWindowInsets = WindowInsets(0, 0, 0, 0),
-            snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
+            snackbarHost = { EverylolToastHost(snackbarHostState) },
             topBar = {
                 EverylolTopAppBar(onBackClick = onBackClick, title = "글 작성하기")
             },

--- a/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/component/CommunityContentWrite.kt
+++ b/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/component/CommunityContentWrite.kt
@@ -143,8 +143,10 @@ fun CommunityContentWriteBlock(
                         },
                         modifier = Modifier.fillMaxWidth(),
                         hint = if (textIndex == 0 && state.content.isEmpty()) {
-                            "- 사진은 최대 10장, 영상은 최대 2개 까지 첨부가능합니다\n" +
-                                    "- 공백 포함 최대 2000자 작성가능합니다"
+                            "· 공백 포함 최대 2000자 작성가능합니다\n" +
+                            "· 과도한 비방 및 욕설이 포함된 게시물은 신고에 의해 무통보 삭제될 수 있습니다\n" +
+                            "· 초상권, 저작권 침해 및 기타 위법한 게시물은 관리자에 의해 무통보 삭제될 수 있습니다.\n" +
+                            "· 사진은 최대 10장, 영상은 최대 2개 까지 첨부가능합니다"
                         } else null
                     )
                 } else {

--- a/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/component/CommunityItem.kt
+++ b/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/component/CommunityItem.kt
@@ -54,7 +54,7 @@ fun CommunityItem(
             )
             Text(
                 text = post.postContent,
-                style = EveryLoLTheme.typography.body02,
+                style = EveryLoLTheme.typography.pretendardBody02,
                 color = EveryLoLTheme.color.community600,
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis

--- a/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/component/CommunityItem.kt
+++ b/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/component/CommunityItem.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
@@ -81,6 +82,7 @@ fun CommunityItem(
 
         }
         CommunityPostActions(
+            isList = true,
             type = type,
             postType = post.postType,
             commentCount = post.commentCounts,
@@ -109,7 +111,7 @@ private fun postThumbnail(
             contentDescription = null,
             contentScale = ContentScale.Crop
         )
-        /*Text(
+        Text(
             modifier = Modifier
                 .align(Alignment.BottomEnd)
                 .padding(3.dp)
@@ -119,6 +121,6 @@ private fun postThumbnail(
             text = "1/${totalCounts}",
             style = EveryLoLTheme.typography.caption02,
             color = EveryLoLTheme.color.grayScale800,
-        )*/
+        )
     }
 }

--- a/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/component/CommunityItem.kt
+++ b/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/component/CommunityItem.kt
@@ -82,9 +82,11 @@ fun CommunityItem(
         }
         CommunityPostActions(
             type = type,
+            postType = post.postType,
             commentCount = post.commentCounts,
-            likeCount = 0,
-            viewCount = 0
+            likeCount = post.likeCount,
+            viewCount = post.viewCount,
+            isLiked = post.isLiked
         )
     }
 }

--- a/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/component/CommunityPostActions.kt
+++ b/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/component/CommunityPostActions.kt
@@ -1,6 +1,5 @@
 package every.lol.com.feature.community.component
 
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
@@ -14,6 +13,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.unit.dp
 import every.lol.com.core.designsystem.theme.EveryLoLTheme
 import every.lol.com.feature.community.model.CommunityUiState
@@ -81,11 +85,22 @@ fun CountBox(
     Row(
         modifier = Modifier
             .clip(RoundedCornerShape(7.dp))
-            .border(
-                width = 1.dp,
-                color = borderColor,
-                shape = RoundedCornerShape(7.dp)
-            )
+            .drawWithContent {
+                drawContent()
+                val strokeWidth = 1.dp.toPx()
+                val halfStrokeWidth = strokeWidth / 2
+
+                drawRoundRect(
+                    color = borderColor,
+                    topLeft = Offset(halfStrokeWidth, halfStrokeWidth),
+                    size = Size(
+                        size.width - strokeWidth,
+                        size.height - strokeWidth
+                    ),
+                    cornerRadius = CornerRadius(7.dp.toPx()),
+                    style = Stroke(width = strokeWidth)
+                )
+            }
             .padding(if(isList) 8.dp else 12.dp, 4.dp)
             .clickable { onCountClick(type) } ,
         horizontalArrangement = Arrangement.spacedBy(4.dp),

--- a/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/component/CommunityPostActions.kt
+++ b/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/component/CommunityPostActions.kt
@@ -48,9 +48,9 @@ fun CommunityPostActions(
             if(postType == null) return
             CategoryBox(category = postType)
         }
-        CountBox(type = 0, count = likeCount, isActive = isLiked, onCountClick = {onLikeClick()})
-        CountBox(type = 1, count = viewCount, isActive = false, onCountClick = {})
-        CountBox(type = 2, count = commentCount, isActive = isCommented, onCountClick = {})
+        CountBox(isList = isList, type = 0, count = likeCount, isActive = isLiked, onCountClick = {onLikeClick()})
+        CountBox(isList = isList, type = 1, count = viewCount, isActive = false, onCountClick = {})
+        CountBox(isList = isList, type = 2, count = commentCount, isActive = isCommented, onCountClick = {})
     }
 }
 
@@ -101,7 +101,7 @@ fun CountBox(
                     style = Stroke(width = strokeWidth)
                 )
             }
-            .padding(if(isList) 8.dp else 12.dp, 4.dp)
+            .padding(if (isList) 8.dp else 12.dp,if(isList) 4.dp else 8.dp)
             .clickable { onCountClick(type) } ,
         horizontalArrangement = Arrangement.spacedBy(4.dp),
         verticalAlignment = Alignment.CenterVertically,

--- a/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/component/CommunityPostActions.kt
+++ b/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/component/CommunityPostActions.kt
@@ -25,7 +25,9 @@ import org.jetbrains.compose.resources.painterResource
 
 @Composable
 fun CommunityPostActions(
+    isList: Boolean = false,
     type: CommunityUiState.CommunityTab?=null,
+    postType: String?=null,
     commentCount: Int,
     likeCount: Int,
     viewCount: Int,
@@ -35,14 +37,15 @@ fun CommunityPostActions(
 ){
     Row(
         modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(14.dp, Alignment.End),
+        horizontalArrangement = Arrangement.spacedBy(if (isList) 14.dp else 8.dp, Alignment.End),
         verticalAlignment = Alignment.CenterVertically
     ){
         if(type == CommunityUiState.CommunityTab.ALL){
-            //CategoryBox(category = type.toString()) //Todo: 카테고리 반영
+            if(postType == null) return
+            CategoryBox(category = postType)
         }
-        //CountBox(type = 0, count = likeCount, isActive = isLiked, onCountClick = {onLikeClick()}) //Todo: 좋아요 개수
-        //CountBox(type = 1, count = viewCount, isActive = false, onCountClick = {}) //Todo: 조회수 개수
+        CountBox(type = 0, count = likeCount, isActive = isLiked, onCountClick = {onLikeClick()})
+        CountBox(type = 1, count = viewCount, isActive = false, onCountClick = {})
         CountBox(type = 2, count = commentCount, isActive = isCommented, onCountClick = {})
     }
 }
@@ -50,6 +53,7 @@ fun CommunityPostActions(
 
 @Composable
 fun CountBox(
+    isList: Boolean = false,
     type: Int, //0: 좋아요, 1: 조회수, 2: 댓글
     count: Int,
     isActive:Boolean,
@@ -82,7 +86,7 @@ fun CountBox(
                 color = borderColor,
                 shape = RoundedCornerShape(7.dp)
             )
-            .padding(8.dp, 4.dp)
+            .padding(if(isList) 8.dp else 12.dp, 4.dp)
             .clickable { onCountClick(type) } ,
         horizontalArrangement = Arrangement.spacedBy(4.dp),
         verticalAlignment = Alignment.CenterVertically,

--- a/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/component/PopularPost.kt
+++ b/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/component/PopularPost.kt
@@ -96,7 +96,7 @@ private fun PopularPostItem(
         )
         Text(
             text = createDate,
-            style = EveryLoLTheme.typography.body02,
+            style = EveryLoLTheme.typography.pretendardBody02,
             color = EveryLoLTheme.color.gray800
         )
     }

--- a/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/component/ReadPost.kt
+++ b/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/component/ReadPost.kt
@@ -31,10 +31,7 @@ fun ReadPost(
     onMoreClick: () -> Unit,
     onImageClick: (String) -> Unit,
     onVideoClick: (String) -> Unit,
-    onLikeClick: () -> Unit = {},
-    isCommented: Boolean = false,
-    isLiked: Boolean = false,
-    likeCount: Int
+    onLikeClick: () -> Unit = {}
 ) {
     Column(
         modifier = Modifier
@@ -100,11 +97,11 @@ fun ReadPost(
         }
 
         CommunityPostActions(
-            isCommented = isCommented,
-            isLiked = isLiked,
+            isCommented = postDetail.isLiked,
+            isLiked = postDetail.isLiked,
             commentCount = postDetail.commentCount,
-            likeCount = likeCount,
-            viewCount = 0,
+            likeCount = postDetail.likeCount,
+            viewCount = postDetail.viewCount,
             onLikeClick = onLikeClick
         )
     }

--- a/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/component/ReadPost.kt
+++ b/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/component/ReadPost.kt
@@ -31,7 +31,10 @@ fun ReadPost(
     onMoreClick: () -> Unit,
     onImageClick: (String) -> Unit,
     onVideoClick: (String) -> Unit,
-    onLikeClick: () -> Unit = {}
+    onLikeClick: () -> Unit = {},
+    isCommented: Boolean = false,
+    isLiked: Boolean = false,
+    likeCount: Int = 0
 ) {
     Column(
         modifier = Modifier
@@ -97,10 +100,10 @@ fun ReadPost(
         }
 
         CommunityPostActions(
-            isCommented = postDetail.isLiked,
-            isLiked = postDetail.isLiked,
+            isCommented = isCommented,
+            isLiked = isLiked,
             commentCount = postDetail.commentCount,
-            likeCount = postDetail.likeCount,
+            likeCount = likeCount,
             viewCount = postDetail.viewCount,
             onLikeClick = onLikeClick
         )

--- a/feature/intro/src/commonMain/kotlin/every/lol/com/feature/intro/IntroScreen.kt
+++ b/feature/intro/src/commonMain/kotlin/every/lol/com/feature/intro/IntroScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -25,6 +24,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import every.lol.com.core.common.EveryLolBackHandler
+import every.lol.com.core.designsystem.component.EverylolToastHost
 import every.lol.com.core.designsystem.theme.EveryLoLTheme
 import every.lol.com.core.ui.component.TosScreen
 import every.lol.com.core.ui.ext.everylolDefault
@@ -61,7 +61,7 @@ internal fun IntroRoute(
     }
 
     Scaffold(
-        snackbarHost = { SnackbarHost(hostState = snackbarHostState) }
+        snackbarHost = { EverylolToastHost(snackbarHostState) }
     ) { paddingValues ->
         Box(modifier = Modifier.padding(paddingValues)) {
             when (val state = uiState) {


### PR DESCRIPTION
- closed #73 

## 📝작업 내용
> 커뮤니티 게시글 정보 가시성 개선 및 좋아요 상호작용 기능 추가

- 게시글 목록/상세 화면 좋아요 및 조회수 UI 반영
- 좋아요 토글 기능 및 API 연동
- 목록 내 이미지/동영상 개수 표시 기능 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
> 게시글 목록에서 미디어 개수를 표시할 때, 이미지와 동영상을 구분하지 않고 합산하여 표시하도록 구현했습니다. 구분 표시가 필요할지 의견 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 게시물 업로드 실패 시 커스텀 토스트 알림 추가
  * 커뮤니티 글쓰기 폼에 상세한 가이드라인 표시

* **버그 수정**
  * 게시물의 정확한 조회수 표시
  * 좋아요 상태 및 개수 동기화 개선

* **스타일**
  * 토스트 알림 UI 디자인 개선
  * 게시물 텍스트 타이포그래피 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->