### PR TITLE
[Feat/#75] 유저 응원팀 저장 및 순위 UI 반영

### DIFF
--- a/composeApp/src/commonMain/kotlin/every/lol/com/di/Koin.kt
+++ b/composeApp/src/commonMain/kotlin/every/lol/com/di/Koin.kt
@@ -37,6 +37,7 @@ import every.lol.com.core.domain.usecase.GetProfileUseCase
 import every.lol.com.core.domain.usecase.GetReadPostUseCase
 import every.lol.com.core.domain.usecase.GetSetPogCandidateUseCase
 import every.lol.com.core.domain.usecase.GetSetPogResultUseCase
+import every.lol.com.core.domain.usecase.GetSupportTeamUseCase
 import every.lol.com.core.domain.usecase.LogoutUseCase
 import every.lol.com.core.domain.usecase.NicknameUseCase
 import every.lol.com.core.domain.usecase.PatchMyTeamUseCase
@@ -106,6 +107,7 @@ val appDependenciesModule = module {
     factory { SignupUseCase(get()) }
     factory { NicknameUseCase(get()) }
     factory { CheckAuthUseCase(get()) }
+    factory { GetSupportTeamUseCase(get()) }
     factory { GetProfileUseCase(get()) }
     factory { PatchProfileUseCase(get()) }
     factory { PatchMyTeamUseCase(get()) }

--- a/core/data/src/commonMain/kotlin/every/lol/com/core/data/repository/AuthRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/every/lol/com/core/data/repository/AuthRepositoryImpl.kt
@@ -46,6 +46,7 @@ class AuthRepositoryImpl(
 
         return remote.signup(signupRequest).toResult()
             .mapCatching { dto ->
+                local.saveSupportTeam(request.teamIds)
                 local.saveUserId(request.kakaoUserId)
                 local.saveToken(dto.accessToken, dto.refreshToken, dto.accessTokenExpirationTime, dto.refreshTokenExpirationTime)
             }
@@ -103,4 +104,8 @@ class AuthRepositoryImpl(
         }
     }
 
+    override suspend fun getSupportTeam(): List<Int>? {
+        val supportTeams = local.getSupportTeamIdsOnce() ?: return null
+        return supportTeams
+    }
 }

--- a/core/data/src/commonMain/kotlin/every/lol/com/core/data/repository/MyPageRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/every/lol/com/core/data/repository/MyPageRepositoryImpl.kt
@@ -22,14 +22,13 @@ class MyPageRepositoryImpl(
         private const val PAGING_SIZE = 10
     }
 
-    override suspend fun getProfile(): Result<UserInform> =
-        remote.getProfile().toResult().mapCatching { response ->
-            UserInform(
-                nickname = response.nickname,
-                profileImage = response.profileImageUrl,
-                teamIds = response.teamIds,
-            )
+    override suspend fun getProfile(): Result<UserInform> {
+        return remote.getProfile().toResult().mapCatching { response ->
+            local.saveSupportTeam(response.teamIds)
+            UserInform(response.nickname,response.profileImageUrl, response.teamIds,)
         }
+    }
+
 
     override suspend fun patchProfile(nickname: String?, profileImage: ByteArray?): Result<Unit> {
         val isDefaultImage = if (profileImage == null) true else false

--- a/core/datastore/src/commonMain/kotlin/every/lol/com/core/datastore/AuthLocalDataSource.kt
+++ b/core/datastore/src/commonMain/kotlin/every/lol/com/core/datastore/AuthLocalDataSource.kt
@@ -1,5 +1,6 @@
 package every.lol.com.core.datastore
 
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.firstOrNull
 
 class AuthLocalDataSource(
@@ -17,7 +18,17 @@ class AuthLocalDataSource(
 
     suspend fun clearAuthData() {
         authPreferences.clearAuthData()
+        authPreferences.clearUserId()
+        authPreferences.clearSupportTeam()
     }
 
     suspend fun getAuthData() = authPreferences.authData.firstOrNull()
+
+    val supportTeamIds: Flow<List<Int>> = authPreferences.supportTeamIds
+
+    suspend fun saveSupportTeam(teamIds: List<Int>) {
+        authPreferences.saveSupportTeam(teamIds)
+    }
+
+    suspend fun getSupportTeamIdsOnce() = authPreferences.supportTeamIds.firstOrNull()
 }

--- a/core/datastore/src/commonMain/kotlin/every/lol/com/core/datastore/AuthPreferences.kt
+++ b/core/datastore/src/commonMain/kotlin/every/lol/com/core/datastore/AuthPreferences.kt
@@ -28,6 +28,7 @@ class AuthPreferences(
         val REFRESH_TOKEN_KEY = stringPreferencesKey("refresh_token")
         val ACCESS_TOKEN_EXPIRATION_TIME_KEY = stringPreferencesKey("access_token_expiration_time")
         val REFRESH_TOKEN_EXPIRATION_TIME_KEY = stringPreferencesKey("refresh_token_expiration_time")
+        val SUPPORT_TEAM_KEY = stringPreferencesKey("support_team")
     }
 
     suspend fun saveUserId(kakaoUserId: String){
@@ -55,6 +56,27 @@ class AuthPreferences(
             preferences.remove(ACCESS_TOKEN_EXPIRATION_TIME_KEY)
             preferences.remove(REFRESH_TOKEN_EXPIRATION_TIME_KEY)
             preferences.remove(KAKAO_USER_ID)
+        }
+    }
+
+    val supportTeamIds: Flow<List<Int>> = dataStore.data.map { preferences ->
+        val teamString = preferences[SUPPORT_TEAM_KEY] ?: ""
+        if (teamString.isEmpty()) {
+            emptyList()
+        } else {
+            teamString.split(",").mapNotNull { it.toIntOrNull() }
+        }
+    }
+
+    suspend fun saveSupportTeam(teamIds: List<Int>) {
+        dataStore.edit { preferences ->
+            preferences[SUPPORT_TEAM_KEY] = teamIds.joinToString(",")
+        }
+    }
+
+    suspend fun clearSupportTeam() {
+        dataStore.edit { preferences ->
+            preferences.remove(SUPPORT_TEAM_KEY)
         }
     }
 }

--- a/core/domain/src/commonMain/kotlin/every/lol/com/core/domain/repository/AuthRepository.kt
+++ b/core/domain/src/commonMain/kotlin/every/lol/com/core/domain/repository/AuthRepository.kt
@@ -9,5 +9,5 @@ interface AuthRepository {
     suspend fun refresh(kakaoUserId: String): Result<Unit>
     suspend fun nickname(nickname: String): Result<Boolean?>
     suspend fun getValidAccessToken(): String?
-
+    suspend fun getSupportTeam(): List<Int>?
 }

--- a/core/domain/src/commonMain/kotlin/every/lol/com/core/domain/usecase/GetSupportTeamUseCase.kt
+++ b/core/domain/src/commonMain/kotlin/every/lol/com/core/domain/usecase/GetSupportTeamUseCase.kt
@@ -1,0 +1,16 @@
+package every.lol.com.core.domain.usecase
+
+import every.lol.com.core.domain.repository.AuthRepository
+
+
+class GetSupportTeamUseCase(
+    private val authRepository: AuthRepository
+) {
+    suspend operator fun invoke(): Result<List<Int>> {
+        return runCatching {
+            val supportTeams = authRepository.getSupportTeam()
+            if(supportTeams != null)   println("응원팀 불러오기 성공")
+            supportTeams ?: emptyList()
+        }
+    }
+}

--- a/core/model/src/commonMain/kotlin/every/lol/com/core/model/Team.kt
+++ b/core/model/src/commonMain/kotlin/every/lol/com/core/model/Team.kt
@@ -17,7 +17,7 @@ enum class Team(
     NONE(0, "선택 안함");
 
     companion object {
-        fun fromId(id: Int?): Team =
+        fun fromTeamId(id: Int?): Team =
             entries.find { it.id == id } ?: NONE
 
         fun fromTeamName(teamName: String?): Team =

--- a/core/ui/src/commonMain/kotlin/every/lol/com/core/ui/component/LCKRankingSection.kt
+++ b/core/ui/src/commonMain/kotlin/every/lol/com/core/ui/component/LCKRankingSection.kt
@@ -1,5 +1,6 @@
 package every.lol.com.core.ui.component
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -18,6 +19,7 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -42,17 +44,29 @@ import org.jetbrains.compose.resources.painterResource
 
 @Composable
 fun LckRankingSection(
-    standings: List<RankingTeam>, //추후 Group으로 수정
+    standings: List<RankingTeam>,
     modifier: Modifier = Modifier,
     onTeamClick: (Long) -> Unit = {},
+    supportTeams : List<Int>,
     // cardBackground: @Composable BoxScope.(LckStandingTeamModel) -> Unit = {}
 ) {
     if (standings.isEmpty()) return
 
-    //val favoriteTeam = standings.firstOrNull { it.teamId == favoriteTeamId }
 
-    val top3 = standings.take(3)
-    val lowerRanks = standings.drop(3)
+    val favoriteTeamId = remember(supportTeams) {
+        supportTeams.randomOrNull()
+    }
+
+    val favoriteTeam = standings.find { fromTeamName(it.teamName).id== favoriteTeamId }
+
+    val remainingTeams = if (favoriteTeam != null) {
+        standings.filter { it.teamName != favoriteTeam.teamName }
+    } else {
+        standings
+    }
+
+    val top3 = remainingTeams.take(3)
+    val lowerRanks = remainingTeams.drop(3)
 
     Column(
         modifier = modifier.fillMaxWidth()
@@ -75,14 +89,12 @@ fun LckRankingSection(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally)
             ) {
-                // Todo: 응원팀 로컬에 저장 및 호출 구현
-                /*favoriteTeam?.let { team ->
-                FavoriteRankCard(
-                    team = team,
-                    onClick = onTeamClick,
-                    cardBackground = cardBackground
-                )
-            }*/
+                favoriteTeam?.let { team ->
+                    FavoriteRankCard(
+                        team = favoriteTeam,
+                        onClick = onTeamClick
+                    )
+                }
                 top3.forEach { team ->
                     TopRankCard(
                         team = team,
@@ -95,15 +107,14 @@ fun LckRankingSection(
             Spacer(modifier = Modifier.height(10.dp))
 
             Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp),
-                verticalArrangement = Arrangement.spacedBy(12.dp)
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 lowerRanks.forEach { team ->
+                    val isMyTeam = supportTeams.contains(fromTeamName(team.teamName).id)
                     RankListRow(
                         team = team,
-                        isFavorite = false,
+                        isFavorite = isMyTeam,
                         onClick = onTeamClick
                     )
                 }
@@ -112,46 +123,57 @@ fun LckRankingSection(
     }
 }
 
-/*@Composable
+@Composable
 private fun FavoriteRankCard(
-    team: HomeRankingTeam,
+    team: RankingTeam,
     onClick: (Long) -> Unit,
     //cardBackground: @Composable BoxScope.(LckStandingTeamModel) -> Unit
 ) {
+
+    val rankingBgRes = when (fromTeamName(team.teamName).id) {
+        1 -> Res.drawable.img_ranking_t1
+        2 -> Res.drawable.img_ranking_gen
+        3 -> Res.drawable.img_ranking_dk
+        4 -> Res.drawable.img_ranking_kt
+        5 -> Res.drawable.img_ranking_hle
+        6 -> Res.drawable.img_ranking_krx
+        7 -> Res.drawable.img_ranking_ns
+        8 -> Res.drawable.img_ranking_bro
+        9 -> Res.drawable.img_ranking_bfx
+        10 -> Res.drawable.img_ranking_dns
+        else -> Res.drawable.img_ranking_t1
+    }
+
     Card(
         modifier = Modifier
             .width(76.dp)
             .height(112.dp)
-            .clickable { onClick(team.teamId) },
+            .clickable { onClick(fromTeamName(team.teamName).id.toLong()) },
         shape = RoundedCornerShape(4.dp),
         colors = CardDefaults.cardColors(
             containerColor = EveryLoLTheme.color.grayScale1000
         ),
-        border = BorderStroke(1.dp, EveryLoLTheme.color.teamT1)
+        border = BorderStroke(1.dp, getTeamColor(team.teamName))
     ) {
         Box(
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier
+                .fillMaxSize()
         ) {
-            cardBackground(team)
-
+            Image(
+                painter = painterResource(rankingBgRes),
+                contentDescription = null,
+                modifier = Modifier.matchParentSize(),
+                contentScale = ContentScale.FillBounds
+            )
             Text(
                 text = "${team.rank}",
                 style = EveryLoLTheme.typography.subtitle03,
                 color = EveryLoLTheme.color.white200,
                 modifier = Modifier.padding(start = 8.dp, top = 7.dp)
             )
-
-            Text(
-                text = team.teamName,
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.Bold,
-                modifier = Modifier
-                    .align(Alignment.BottomEnd)
-                    .padding(end = 10.dp, bottom = 10.dp)
-            )
         }
     }
-}*/
+}
 
 @Composable
 private fun TopRankCard(
@@ -194,7 +216,7 @@ private fun TopRankCard(
                 painter = painterResource(rankingBgRes),
                 contentDescription = null,
                 modifier = Modifier.matchParentSize(),
-                contentScale = ContentScale.FillBounds // 전체를 꽉 채움
+                contentScale = ContentScale.FillBounds
             )
             Text(
                 text = "${team.rank}",
@@ -224,17 +246,17 @@ private fun RankListRow(
                 val teamId = fromTeamName(team.teamName).id.toLong()
                 onClick(teamId)
             }
-            .padding(horizontal = 8.dp, vertical = 8.dp),
+            .padding(horizontal = 8.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         Text(
             text = "${team.rank}",
             style = EveryLoLTheme.typography.subtitle03,
             color = EveryLoLTheme.color.white200,
-            modifier = Modifier.width(10.dp)
+            modifier = Modifier.width(20.dp)
         )
 
-        Spacer(modifier = Modifier.width(30.dp))
+        Spacer(modifier = Modifier.width(19.dp))
 
         Text(
             text = team.teamName,

--- a/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/AboutLCKScreen.kt
+++ b/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/AboutLCKScreen.kt
@@ -89,6 +89,7 @@ fun AboutLCKScreen(
     val ranking = aboutLCKState?.ranking?.groups?.firstOrNull()?.teams ?: emptyList()
     val matches = aboutLCKState?.match?.matches ?: emptyList()
     var showCalender =  remember { mutableStateOf(false) }
+    val supportTeams = aboutLCKState?.supportTeam ?: emptyList()
 
     Box(modifier = Modifier.fillMaxSize()) {
         Scaffold(
@@ -156,7 +157,7 @@ fun AboutLCKScreen(
                 item {
                     LckRankingSection(
                         standings = ranking,
-                        //favoriteTeamId = myFavoriteTeamId,
+                        supportTeams = supportTeams,
                         modifier = Modifier.padding(top = 24.dp),
                         onTeamClick = { teamId ->
                             // TODO

--- a/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/AboutLCKViewModel.kt
+++ b/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/AboutLCKViewModel.kt
@@ -1,6 +1,7 @@
 package every.lol.com.feature.aboutlck
 
 import every.lol.com.core.domain.usecase.GetHomeRankingUseCase
+import every.lol.com.core.domain.usecase.GetSupportTeamUseCase
 import every.lol.com.core.domain.usecase.aboutlck.GetAboutLCKMatchUseCase
 import every.lol.com.feature.aboutlck.model.AboutLCKIntent
 import every.lol.com.feature.aboutlck.model.AboutLCKUiState
@@ -21,6 +22,7 @@ sealed interface AboutLCKEvent{
 class AboutLCKViewModel(
     private val getAboutLCKMatchUseCase: GetAboutLCKMatchUseCase,
     private val getHomeRankingUseCase: GetHomeRankingUseCase,
+    private val getSupportTeamUseCase: GetSupportTeamUseCase
     ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<AboutLCKUiState>(AboutLCKUiState.Loading)
@@ -77,12 +79,15 @@ class AboutLCKViewModel(
     private fun loadRanking() {
         viewModelScope.launch {
             getHomeRankingUseCase().onSuccess { result ->
-                _uiState.update { state ->
-                    val currentState = state as? AboutLCKUiState.AboutLCK ?:AboutLCKUiState.AboutLCK()
-                    currentState.copy(
-                        isLoading = false,
-                        ranking = result
-                    )
+                getSupportTeamUseCase().onSuccess { supportTeam ->
+                    _uiState.update { state ->
+                        val currentState = state as? AboutLCKUiState.AboutLCK ?:AboutLCKUiState.AboutLCK()
+                        currentState.copy(
+                            isLoading = false,
+                            ranking = result,
+                            supportTeam = supportTeam
+                        )
+                    }
                 }
             }.onFailure { error ->
                 _uiState.update { state ->

--- a/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/model/AboutLCKUiModel.kt
+++ b/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/model/AboutLCKUiModel.kt
@@ -11,6 +11,7 @@ sealed interface AboutLCKUiState {
     data class AboutLCK(
         val isLoading: Boolean = false,
         val ranking: Ranking?= null,
+        val supportTeam: List<Int> = emptyList(),
         val match: AboutLCKMatch?= null
         ) : AboutLCKUiState
 }

--- a/feature/home/src/commonMain/kotlin/every/lol/com/feature/home/HomeScreen.kt
+++ b/feature/home/src/commonMain/kotlin/every/lol/com/feature/home/HomeScreen.kt
@@ -86,7 +86,7 @@ fun HomeScreen(
     val newsBanners = homeState?.news
     val alertsMessage = homeState?.alertsMessage
     val ranking = homeState?.ranking?.groups?.firstOrNull()?.teams ?: emptyList()
-    val myFavoriteTeamId = 6L
+    val supportTeams = homeState?.supportTeam ?: emptyList()
 
     LazyColumn(
         modifier = Modifier
@@ -151,7 +151,7 @@ fun HomeScreen(
         item {
             LckRankingSection(
                 standings = ranking,
-                //favoriteTeamId = myFavoriteTeamId,
+                supportTeams = supportTeams,
                 modifier = Modifier.padding(top = 24.dp).padding(horizontal = 16.dp),
                 onTeamClick = { teamId ->
                     // TODO

--- a/feature/home/src/commonMain/kotlin/every/lol/com/feature/home/HomeViewModel.kt
+++ b/feature/home/src/commonMain/kotlin/every/lol/com/feature/home/HomeViewModel.kt
@@ -5,6 +5,7 @@ import every.lol.com.core.domain.usecase.GetHomeNewsUseCase
 import every.lol.com.core.domain.usecase.GetHomeRankingUseCase
 import every.lol.com.core.domain.usecase.GetHomeTodayMatchUseCase
 import every.lol.com.core.domain.usecase.GetMatchVoteRateUseCase
+import every.lol.com.core.domain.usecase.GetSupportTeamUseCase
 import every.lol.com.feature.home.model.HomeIntent
 import every.lol.com.feature.home.model.HomeUiState
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -23,6 +24,7 @@ sealed interface HomeEvent{
 class HomeViewModel(
     private val getHomeTodayMatchUseCase: GetHomeTodayMatchUseCase,
     private val getHomeRankingUseCase: GetHomeRankingUseCase,
+    private val getSupportTeamUseCase: GetSupportTeamUseCase,
     private val getHomeNewsUseCase: GetHomeNewsUseCase,
     private val getHomeAlertsUseCase: GetHomeAlertsUseCase,
     private val getMatchVotestUseCase: GetMatchVoteRateUseCase
@@ -128,13 +130,15 @@ class HomeViewModel(
     private fun loadRanking() {
         viewModelScope.launch {
             getHomeRankingUseCase().onSuccess { result ->
-                _uiState.update { state ->
-                    val currentState = state as? HomeUiState.Home ?: HomeUiState.Home()
-                    currentState.copy(
-                        isLoading = false,
-                        ranking = result,
-                        isRefreshing = false
-                    )
+                getSupportTeamUseCase().onSuccess { supportTeam ->
+                    _uiState.update { state ->
+                        val currentState = state as? HomeUiState.Home ?: HomeUiState.Home()
+                        currentState.copy(
+                            isLoading = false,
+                            ranking = result,
+                            supportTeam = supportTeam
+                        )
+                    }
                 }
             }.onFailure { error ->
                 _uiState.update { state ->

--- a/feature/home/src/commonMain/kotlin/every/lol/com/feature/home/model/HomeUiModel.kt
+++ b/feature/home/src/commonMain/kotlin/every/lol/com/feature/home/model/HomeUiModel.kt
@@ -16,6 +16,7 @@ sealed interface HomeUiState {
         val matches: HomeTodayMatch ?= null,
         val matchRates: Map<Long, MatchVoteRate> = emptyMap(),
         val ranking: Ranking?= null,
+        val supportTeam: List<Int> = emptyList(),
         val news: HomeNews?=null,
         val alerts: HomeAlerts?=null,
         val alertsMessage: String?=null,

--- a/feature/mypage/src/commonMain/kotlin/every/lol/com/feature/mypage/MypageViewModel.kt
+++ b/feature/mypage/src/commonMain/kotlin/every/lol/com/feature/mypage/MypageViewModel.kt
@@ -114,7 +114,7 @@ class MypageViewModel(
                 val myInform = MypageUiState.MyInform(
                     nickName = userInform.nickname,
                     teamIds = userInform.teamIds.mapNotNull { id ->
-                        Team.fromId(id)
+                        Team.fromTeamId(id)
                     }.toSet(),
                     profileImage = userInform.profileImage
                 )

--- a/feature/mypage/src/commonMain/kotlin/every/lol/com/feature/mypage/component/MVPItem.kt
+++ b/feature/mypage/src/commonMain/kotlin/every/lol/com/feature/mypage/component/MVPItem.kt
@@ -25,7 +25,7 @@ import every.lol.com.feature.mypage.model.MypageUiState
 fun MVPItem(
     mvp: MypageUiState.MVPItem
 ) {
-    val team = Team.fromId(mvp.playerTeam)
+    val team = Team.fromTeamId(mvp.playerTeam)
     Column(
         modifier = Modifier
             .fillMaxWidth()

--- a/feature/mypage/src/commonMain/kotlin/every/lol/com/feature/mypage/component/PredictionItem.kt
+++ b/feature/mypage/src/commonMain/kotlin/every/lol/com/feature/mypage/component/PredictionItem.kt
@@ -97,7 +97,7 @@ private fun TeamText(
     isWinner: Boolean = false,
     isMyVote: Boolean = false
 ){
-    val team = Team.fromId(teamId)
+    val team = Team.fromTeamId(teamId)
     Text(
         modifier = modifier
             .clip(RoundedCornerShape(4.dp))


### PR DESCRIPTION
- closed #75 

## 📝작업 내용
> 유저 응원팀 로컬 저장 기능 구현 및 LCK 순위 화면 연동

- 로컬 저장소를 활용한 유저 응원팀 정보 영속화
- LCK 순위 리스트 내 응원팀 하이라이트 UI 적용
- 응원팀 설정 변경 시 순위 화면 동기화 처리

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
> 로컬 저장소 선택 시 확장성을 고려하여 구현하였는데, 추후 서버 동기화 필요 여부에 대해 의견 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 선호하는 팀 저장 및 관리 기능 추가
  * 랭킹 화면에서 선호하는 팀 강조 표시 개선
  * 프로필 페이지에서 팀 정보 자동 저장 및 조회 기능

<!-- end of auto-generated comment: release notes by coderabbit.ai -->