### PR TITLE
[FEAT/#77] 응원팀 알람 다중 설정 및 null 처리

### DIFF
--- a/feature/home/src/commonMain/kotlin/every/lol/com/feature/home/HomeScreen.kt
+++ b/feature/home/src/commonMain/kotlin/every/lol/com/feature/home/HomeScreen.kt
@@ -1,7 +1,9 @@
 package every.lol.com.feature.home
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -9,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -84,7 +87,7 @@ fun HomeScreen(
     var showMatchBanner by rememberSaveable { mutableStateOf(true) }
     val matchData = homeState?.matches
     val newsBanners = homeState?.news
-    val alertsMessage = homeState?.alertsMessage
+    val currentAlerts = homeState?.alerts?.alerts ?: emptyList()
     val ranking = homeState?.ranking?.groups?.firstOrNull()?.teams ?: emptyList()
     val supportTeams = homeState?.supportTeam ?: emptyList()
 
@@ -104,24 +107,25 @@ fun HomeScreen(
                 }
             )
         }
-        alertsMessage?.let {
-            item {
-                if (showMatchBanner) {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 16.dp)
-                            .padding(top = 16.dp)
-                    ) {
-                        MatchNoticeBanner(
-                            message = alertsMessage.toString(),
-                            onCloseClick = { showMatchBanner = false }
-                        )
+        items(
+            items = currentAlerts,
+            key = { it.matchId }
+        ) { alert ->
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+                    .padding(top = 16.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                MatchNoticeBanner(
+                    message = alert.message,
+                    onCloseClick = {
+                        onIntent(HomeIntent.CloseAlarm(alert.matchId))
                     }
-                }
+                )
             }
         }
-
         item {
 
             MatchCardRow(

--- a/feature/home/src/commonMain/kotlin/every/lol/com/feature/home/HomeViewModel.kt
+++ b/feature/home/src/commonMain/kotlin/every/lol/com/feature/home/HomeViewModel.kt
@@ -6,6 +6,7 @@ import every.lol.com.core.domain.usecase.GetHomeRankingUseCase
 import every.lol.com.core.domain.usecase.GetHomeTodayMatchUseCase
 import every.lol.com.core.domain.usecase.GetMatchVoteRateUseCase
 import every.lol.com.core.domain.usecase.GetSupportTeamUseCase
+import every.lol.com.core.model.HomeAlerts
 import every.lol.com.feature.home.model.HomeIntent
 import every.lol.com.feature.home.model.HomeUiState
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -43,6 +44,7 @@ class HomeViewModel(
     fun onIntent(intent: HomeIntent) {
         when (intent) {
             HomeIntent.LoadInitial -> loadInitial()
+            is HomeIntent.CloseAlarm -> dismissAlarm(intent.matchId)
             HomeIntent.RefreshHome -> refreshHome()
             HomeIntent.LoadTodayMatchHome -> loadTodayMatchHome()
             else -> {}
@@ -176,27 +178,38 @@ class HomeViewModel(
         }
     }
 
-    private fun loadAlerts(){
+    private fun loadAlerts() {
         viewModelScope.launch {
             getHomeAlertsUseCase().onSuccess { result ->
-                _uiState.update { state ->
-                    val currentState = state as? HomeUiState.Home ?: HomeUiState.Home()
-                    currentState.copy(
-                        isLoading = false,
-                        alerts = result,
-                        isRefreshing = false,
-                        alertsMessage = result.alerts.firstOrNull()?.message.orEmpty()
-                    )
-                }
+                rawAlerts = result
+                updateAlertsState()
             }.onFailure {
-                _uiState.update {
-                    val currentState = it as? HomeUiState.Home ?: HomeUiState.Home()
-                    currentState.copy(isLoading = false)
-                }
-                isInitialLoaded = false
-                println(it)
+
             }
         }
+    }
+
+    private fun updateAlertsState() {
+        _uiState.update { state ->
+            val currentState = state as? HomeUiState.Home ?: return@update state
+            val alertsData = rawAlerts ?: return@update state
+
+            val filteredList = alertsData.alerts.filter { it.matchId !in dismissedMatchIds }
+
+            currentState.copy(
+                alerts = alertsData.copy(
+                    alerts = filteredList,
+                    alertCount = filteredList.size
+                )
+            )
+        }
+    }
+    private val dismissedMatchIds = mutableSetOf<Int>()
+    private var rawAlerts: HomeAlerts? = null
+
+    private fun dismissAlarm(matchId: Int) {
+        dismissedMatchIds.add(matchId)
+        updateAlertsState()
     }
 
 }

--- a/feature/home/src/commonMain/kotlin/every/lol/com/feature/home/model/HomeUiModel.kt
+++ b/feature/home/src/commonMain/kotlin/every/lol/com/feature/home/model/HomeUiModel.kt
@@ -2,6 +2,7 @@ package every.lol.com.feature.home.model
 
 import androidx.compose.runtime.Immutable
 import every.lol.com.core.model.HomeAlerts
+import every.lol.com.core.model.HomeAlertsDetail
 import every.lol.com.core.model.HomeNews
 import every.lol.com.core.model.HomeTodayMatch
 import every.lol.com.core.model.MatchVoteRate
@@ -32,5 +33,6 @@ sealed interface HomeIntent {
     data object LoadInitial : HomeIntent
     data object RefreshHome : HomeIntent
     data object LoadTodayMatchHome : HomeIntent
+    data class CloseAlarm(val matchId: Int) : HomeIntent
     data class ClickMatchCard(val matchId: Long) : HomeIntent
 }


### PR DESCRIPTION
- closed #77 

## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 경기 알림을 개별적으로 닫을 수 있습니다.
* 닫은 알림은 새로고침 후에도 유지됩니다.
* 여러 경기 알림이 목록 형식으로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->