### PR TITLE
[Feat/#64] todays matches api 수정

### DIFF
--- a/core/model/src/commonMain/kotlin/every/lol/com/core/model/MatchCard.kt
+++ b/core/model/src/commonMain/kotlin/every/lol/com/core/model/MatchCard.kt
@@ -14,7 +14,8 @@ data class MatchCardModel(
     val team1VoteRate: Double = 0.0,
     val team2VoteRate: Double = 0.0,
     val totalVoteCount: Int = 0,
-    val predictedWinnerTeamName: String? = null
+    val predictedWinnerTeamName: String? = null,
+    val actualWinnerTeamName: String? = null
 )
 
 data class MatchInfo(

--- a/feature/home/src/commonMain/kotlin/every/lol/com/feature/home/component/MatchCard.kt
+++ b/feature/home/src/commonMain/kotlin/every/lol/com/feature/home/component/MatchCard.kt
@@ -83,21 +83,65 @@ fun MatchCard(
     modifier: Modifier = Modifier,
     onClick: (Long) -> Unit = {}
 ) {
+    if (matchCard == null) {
+        Card(
+            modifier = modifier,
+            shape = RoundedCornerShape(8.dp),
+            colors = CardDefaults.cardColors(
+                containerColor = EveryLoLTheme.color.newBg
+            ),
+            border = BorderStroke(
+                1.dp,
+                EveryLoLTheme.color.grayScale900
+            )
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp, vertical = 28.dp)
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.Top
+                ) {
+                    Text(
+                        text = "No Match",
+                        color = EveryLoLTheme.color.grayScale100,
+                        style = EveryLoLTheme.typography.title01,
+                        modifier = Modifier.weight(1f)
+                    )
 
-    val team1Progress = voteRate?.team1?.voteRate?.toFloat() ?: 0.5f
-    val team2Progress = voteRate?.team2?.voteRate?.toFloat() ?: 0.5f
+                    Box(
+                        modifier = Modifier
+                            .size(10.dp)
+                            .clip(CircleShape)
+                            .background(EveryLoLTheme.color.grayScale800)
+                    )
+                }
 
-    val statusColor = when(matchCard?.matchStatus){
+                Spacer(modifier = Modifier.height(60.dp))
+
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    NoMatchBarRow()
+                    NoMatchBarRow()
+                }
+            }
+        }
+        return
+    }
+
+    val team1Progress = voteRate?.team1?.voteRate?.toFloat()?.div(100f) ?: 0.5f
+    val team2Progress = voteRate?.team2?.voteRate?.toFloat()?.div(100f) ?: 0.5f
+
+    val statusColor = when(matchCard.matchStatus){
         "LIVE" -> EveryLoLTheme.color.semanticWarning
         else -> EveryLoLTheme.color.grayScale800
     }
 
     Card(
-        modifier = modifier
-            .then(
-                if (matchCard != null) Modifier.clickable { onClick(matchCard.matchId) }
-                else Modifier
-            ),
+        modifier = modifier.clickable { onClick(matchCard.matchId) },
         shape = RoundedCornerShape(8.dp),
         colors = CardDefaults.cardColors(
             containerColor = EveryLoLTheme.color.newBg
@@ -120,7 +164,7 @@ fun MatchCard(
                     modifier = Modifier.weight(1f)
                 ) {
                     Text(
-                        text = if(matchCard != null)matchCard.seasonName else "No Match",
+                        text = matchCard.seasonName,
                         color = EveryLoLTheme.color.grayScale100,
                         style = EveryLoLTheme.typography.title01
                     )
@@ -129,16 +173,14 @@ fun MatchCard(
 
                     Row(
                         horizontalArrangement = Arrangement.spacedBy(4.dp)
-                    ) {if (matchCard != null) {
-                        if(matchCard.groupName != null){
-                            MatchCardTag(text = matchCard.groupName)
-                            MatchCardTag(text = matchCard.roundName)
-                        }
+                    ) {
+                        matchCard.groupName
+                            ?.takeIf { it.isNotBlank() }
+                            ?.let { groupName ->
+                                MatchCardTag(text = groupName)
+                            }
+
                         MatchCardTag(text = matchCard.roundName)
-                    } else {
-                        MatchCardTag(text = "")
-                        MatchCardTag(text = "")
-                    }
                     }
                 }
 
@@ -156,9 +198,9 @@ fun MatchCard(
                 verticalArrangement = Arrangement.spacedBy(12.dp)
             ) {
                 MatchCardBarRow(
-                    teamName = if (matchCard != null) matchCard.team1.teamName else "-",
+                    teamName = matchCard.team1.teamName,
                     progress = team1Progress,
-                    barColor = if (matchCard == null || (( matchCard.matchStatus == "FINISHED") &&  !matchCard.team1.winner)) {
+                    barColor = if (matchCard.matchStatus == "FINISHED" && !matchCard.team1.winner) {
                         SolidColor(EveryLoLTheme.color.grayScale800)
                     } else {
                         getTeamBrush(matchCard.team1.teamId.toInt())
@@ -166,9 +208,9 @@ fun MatchCard(
                 )
 
                 MatchCardBarRow(
-                    teamName = if(matchCard != null) matchCard.team2.teamName else ("-"),
+                    teamName = matchCard.team2.teamName,
                     progress = team2Progress,
-                    barColor = if (matchCard == null || (( matchCard.matchStatus == "FINISHED") && !matchCard.team2.winner)) {
+                    barColor = if (matchCard.matchStatus == "FINISHED" && !matchCard.team2.winner) {
                         SolidColor(EveryLoLTheme.color.grayScale800)
                     } else {
                         getTeamBrush(matchCard.team2.teamId.toInt())
@@ -238,18 +280,43 @@ private fun MatchCardBarRow(
 }
 
 @Composable
+private fun NoMatchBarRow(
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = "-",
+            style = EveryLoLTheme.typography.body03,
+            color = EveryLoLTheme.color.grayScale700,
+            modifier = Modifier.width(57.dp)
+        )
+
+        Box(
+            modifier = Modifier
+                .width(24.dp)
+                .height(12.dp)
+                .clip(RoundedCornerShape(8.dp))
+                .background(EveryLoLTheme.color.grayScale700)
+        )
+    }
+}
+
+@Composable
 fun getTeamBrush(id : Int): Brush {
     return when (id) {
-        1 -> SolidColor(EveryLoLTheme.color.teamGen)
-        2 -> SolidColor(EveryLoLTheme.color.teamT1)
-        3 -> SolidColor(EveryLoLTheme.color.teamNS)
-        4 -> SolidColor(EveryLoLTheme.color.teamDNS)
-        5 -> SolidColor(EveryLoLTheme.color.teamBRO)
-        6 -> SolidColor(EveryLoLTheme.color.teamBFX)
-        7 -> SolidColor(EveryLoLTheme.color.teamDK)
-        8 -> SolidColor(EveryLoLTheme.color.teamKRX)
-        9 -> SolidColor(EveryLoLTheme.color.teamKT)
-        10 -> SolidColor(EveryLoLTheme.color.teamHLE)
+        1 -> SolidColor(EveryLoLTheme.color.teamT1)
+        2 -> SolidColor(EveryLoLTheme.color.teamGen)
+        3 -> SolidColor(EveryLoLTheme.color.teamDK)
+        4 -> SolidColor(EveryLoLTheme.color.teamKT)
+        5 -> SolidColor(EveryLoLTheme.color.teamHLE)
+        6 -> SolidColor(EveryLoLTheme.color.teamKRX)
+        7 -> SolidColor(EveryLoLTheme.color.teamNS)
+        8 -> SolidColor(EveryLoLTheme.color.teamBRO)
+        9 -> SolidColor(EveryLoLTheme.color.teamBFX)
+        10 -> SolidColor(EveryLoLTheme.color.teamDNS)
         else -> SolidColor(Color.Transparent)
     }
 }

--- a/feature/matches/src/commonMain/kotlin/every/lol/com/feature/matches/MatchesViewModel.kt
+++ b/feature/matches/src/commonMain/kotlin/every/lol/com/feature/matches/MatchesViewModel.kt
@@ -197,6 +197,11 @@ class MatchesViewModel(
                                 (voteRate?.team1?.voteRate ?: 0.0) > (voteRate?.team2?.voteRate ?: 0.0) -> match.team1.teamName
                                 (voteRate?.team2?.voteRate ?: 0.0) > (voteRate?.team1?.voteRate ?: 0.0) -> match.team2.teamName
                                 else -> null
+                            },
+                            actualWinnerTeamName = when {
+                                match.team1.winner -> match.team1.teamName
+                                match.team2.winner -> match.team2.teamName
+                                else -> null
                             }
                         )
                     }

--- a/feature/matches/src/commonMain/kotlin/every/lol/com/feature/matches/PredictionScreen.kt
+++ b/feature/matches/src/commonMain/kotlin/every/lol/com/feature/matches/PredictionScreen.kt
@@ -22,6 +22,7 @@ import every.lol.com.core.designsystem.theme.EveryLoLTheme
 import every.lol.com.core.model.MatchCardModel
 import every.lol.com.core.model.MatchPogCandidate
 import every.lol.com.core.model.MatchStatus
+import every.lol.com.core.model.PogCandidateCandidate
 import every.lol.com.core.model.SetPogVoteItem
 import every.lol.com.feature.matches.component.CompactMatchCard
 import every.lol.com.feature.matches.component.IncompletePogVoteDialog
@@ -93,8 +94,11 @@ fun PredictionScreen(
                         PogVoteItem(
                             title = "${setDetail.setIndex}세트 POG를 선택해주세요",
                             options = setDetail.candidates.map { it.playerName } + "해당없음",
-                            isExpanded = index == 0,
-                            selectedOption = null
+                            isExpanded = false,
+                            selectedOption = resolveSelectedOption(
+                                myVotedPlayerId = setDetail.myVotedPlayerId,
+                                candidates = setDetail.candidates
+                            )
                         )
                     )
                 }
@@ -105,7 +109,10 @@ fun PredictionScreen(
                             title = "POM을 선택해주세요",
                             options = matchPog.candidates.map { it.playerName } + "해당없음",
                             isExpanded = false,
-                            selectedOption = null
+                            selectedOption = resolveSelectedOption(
+                                myVotedPlayerId = matchPog.myVotedPlayerId,
+                                candidates = matchPog.candidates
+                            )
                         )
                     )
                 }
@@ -119,6 +126,9 @@ fun PredictionScreen(
         val prefix = if (index == voteItems.lastIndex) "POM" else "${index + 1}세트"
         "$prefix : ${item.selectedOption ?: "투표 안 함"}"
     }
+
+    val hasSavedVote = state.setPogData.orEmpty().any { it.myVotedPlayerId != null } ||
+            (state.matchPogData?.myVotedPlayerId != null)
 
     Column(
         modifier = modifier
@@ -174,8 +184,8 @@ fun PredictionScreen(
 
             item {
                 val currentMode = when {
-                    state.setPogData.isNullOrEmpty() -> PogSectionMode.WAITING
-                    state.isPogSaved -> PogSectionMode.SAVED
+                    state.setPogData.isNullOrEmpty() && state.matchPogData == null -> PogSectionMode.WAITING
+                    state.isPogSaved || hasSavedVote -> PogSectionMode.SAVED
                     else -> PogSectionMode.VOTING
                 }
                 PogSection(
@@ -205,7 +215,7 @@ fun PredictionScreen(
                             val selectedOption = voteItems.getOrNull(index)?.selectedOption
 
                             val playerId: Long? = when (selectedOption) {
-                                null, "해당없음" -> null
+                                null, "해당없음" -> if (selectedOption == "해당없음") -1L else null
                                 else -> setDetail.candidates
                                     .find { it.playerName == selectedOption }
                                     ?.playerId
@@ -220,7 +230,7 @@ fun PredictionScreen(
 
                         val pomSelectedOption = voteItems.lastOrNull()?.selectedOption
                         val pomPlayerId: Long? = when (pomSelectedOption) {
-                            null, "해당없음" -> null
+                            null, "해당없음" -> if (pomSelectedOption == "해당없음") -1L else null
                             else -> state.matchPogData?.candidates
                                 ?.find { it.playerName == pomSelectedOption }
                                 ?.playerId
@@ -277,5 +287,16 @@ fun PredictionScreen(
                 onSavePogVotes(setVotes, pomPlayerId)
             }
         )
+    }
+}
+
+private fun resolveSelectedOption(
+    myVotedPlayerId: Long?,
+    candidates: List<PogCandidateCandidate>
+): String? {
+    return when (myVotedPlayerId) {
+        null -> null
+        -1L -> "해당없음"
+        else -> candidates.firstOrNull { it.playerId.toLong() == myVotedPlayerId }?.playerName
     }
 }

--- a/feature/matches/src/commonMain/kotlin/every/lol/com/feature/matches/component/DetailMatchCard.kt
+++ b/feature/matches/src/commonMain/kotlin/every/lol/com/feature/matches/component/DetailMatchCard.kt
@@ -39,6 +39,10 @@ fun DetailMatchCard(
     onOpenTalkClick: () -> Unit = {},
     onPredictionClick: () -> Unit = {}
 ) {
+    val displayWinnerTeamName = when (item.matchStatus) {
+        MatchStatus.FINISHED -> item.actualWinnerTeamName
+        else -> item.predictedWinnerTeamName
+    }
     Column(
         modifier = modifier
             .width(328.dp)
@@ -68,12 +72,12 @@ fun DetailMatchCard(
                         }
                     MatchCardTag(text = item.roundName)
 
-                    item.predictedWinnerTeamName
+                    displayWinnerTeamName
                         ?.takeIf { it.isNotBlank() }
-                        ?.let { predictedWinner ->
+                        ?.let { winnerTeamName ->
                             MatchCardTag(
-                                text = "$predictedWinner win",
-                                backgroundColor = getTeamColor(predictedWinner),
+                                text = "$winnerTeamName win",
+                                backgroundColor = getTeamColor(winnerTeamName),
                                 textColor = EveryLoLTheme.color.black900
                             )
                         }
@@ -118,13 +122,13 @@ fun DetailMatchCard(
                 team2Rate = item.team2VoteRate,
                 team1Name = item.team1Name,
                 team2Name = item.team2Name,
-                predictedWinnerTeamName = item.predictedWinnerTeamName
+                predictedWinnerTeamName = displayWinnerTeamName
             )
 
             TeamNameRow(
                 team1Name = item.team1Name,
                 team2Name = item.team2Name,
-                predictedWinnerTeamName = item.predictedWinnerTeamName,
+                predictedWinnerTeamName = displayWinnerTeamName,
                 status = item.matchStatus
             )
         }

--- a/feature/matches/src/commonMain/kotlin/every/lol/com/feature/matches/component/PogSection.kt
+++ b/feature/matches/src/commonMain/kotlin/every/lol/com/feature/matches/component/PogSection.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import every.lol.com.core.designsystem.theme.EveryLoLTheme
+import every.lol.com.core.model.PogCandidateCandidate
 import everylol.feature.matches.generated.resources.Res
 import everylol.feature.matches.generated.resources.ic_double_arrow_right
 import everylol.feature.matches.generated.resources.ic_dropdown_down
@@ -71,8 +72,7 @@ fun PogSection(
 
                 PogWaitingCard()
             }
-            PogSectionMode.VOTING,
-            PogSectionMode.SAVED -> {
+            PogSectionMode.VOTING -> {
                 Text(
                     text = title,
                     color = EveryLoLTheme.color.grayScale600,
@@ -97,8 +97,30 @@ fun PogSection(
                 }
 
                 PogBottomButtons(
-                    isSaved = mode == PogSectionMode.SAVED,
-                    isSaveEnabled = mode != PogSectionMode.SAVED,
+                    isSaved = false,
+                    isSaveEnabled = isSaveEnabled,
+                    onSaveClick = onSaveClick,
+                    onResultClick = onResultClick
+                )
+            }
+            PogSectionMode.SAVED -> {
+                Text(
+                    text = title,
+                    color = EveryLoLTheme.color.grayScale600,
+                    style = EveryLoLTheme.typography.subtitle03
+                )
+
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    savedItems.forEach { text ->
+                        PogSavedItemCard(text = text)
+                    }
+                }
+
+                PogBottomButtons(
+                    isSaved = true,
+                    isSaveEnabled = false,
                     onSaveClick = onSaveClick,
                     onResultClick = onResultClick
                 )
@@ -398,5 +420,27 @@ fun IncompletePogVoteDialog(
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun PogSavedItemCard(
+    text: String,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .width(328.dp)
+            .height(44.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .background(EveryLoLTheme.color.grayScale1000)
+            .padding(horizontal = 16.dp),
+        contentAlignment = Alignment.CenterStart
+    ) {
+        Text(
+            text = text,
+            color = EveryLoLTheme.color.grayScale100,
+            style = EveryLoLTheme.typography.body01
+        )
     }
 }


### PR DESCRIPTION
- closed #64 

## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
승부 예측 시 자기가 선택한 팀으로 승리 표시되던 현상 수정
POG 투표 저장 기능 구현
홈 경기화면 경기 없는 날 UI 구현

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 경기 완료 시 실제 우승팀 정보를 표시하도록 개선
  * POG(Player of the Game) 투표 저장 및 조회 기능 추가
  * POG 저장된 투표 이력 화면에 표시

* **개선 사항**
  * 경기 예측과 실제 결과를 구분하여 표시
  * 매치 카드 UI의 "매치 없음" 상태 추가
  * POG 투표 인터페이스 개선 및 투표 상태 관리 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->