### PR TITLE
[Feat/#80] mypage 승부예측 mvp 투표 api 연

### DIFF
--- a/composeApp/src/commonMain/kotlin/every/lol/com/di/Koin.kt
+++ b/composeApp/src/commonMain/kotlin/every/lol/com/di/Koin.kt
@@ -33,6 +33,7 @@ import every.lol.com.core.domain.usecase.GetMatchesCandidateUseCase
 import every.lol.com.core.domain.usecase.GetMatchesUseCase
 import every.lol.com.core.domain.usecase.GetMyCommentsUseCase
 import every.lol.com.core.domain.usecase.GetMyPostsUseCase
+import every.lol.com.core.domain.usecase.GetMyPredictionsUseCase
 import every.lol.com.core.domain.usecase.GetProfileUseCase
 import every.lol.com.core.domain.usecase.GetReadPostUseCase
 import every.lol.com.core.domain.usecase.GetSetPogCandidateUseCase
@@ -136,12 +137,11 @@ val appDependenciesModule = module {
     factory { PostMatchPogVoteUseCase(get()) }
     factory { GetSetPogResultUseCase(get()) }
     factory { GetMatchPogResultUseCase(get()) }
-
     factory { GetMatchPogCandidateUseCase(get()) }
     factory { GetMatchesCandidateUseCase(get()) }
     factory { GetSetPogCandidateUseCase(get()) }
-
     factory { GetAboutLCKMatchUseCase(get())  }
+    factory { GetMyPredictionsUseCase(get()) }
 
     factoryOf(::IntroViewModel)
     factoryOf(::HomeViewModel)

--- a/composeApp/src/commonMain/kotlin/every/lol/com/di/Koin.kt
+++ b/composeApp/src/commonMain/kotlin/every/lol/com/di/Koin.kt
@@ -33,7 +33,6 @@ import every.lol.com.core.domain.usecase.GetMatchesCandidateUseCase
 import every.lol.com.core.domain.usecase.GetMatchesUseCase
 import every.lol.com.core.domain.usecase.GetMyCommentsUseCase
 import every.lol.com.core.domain.usecase.GetMyPostsUseCase
-import every.lol.com.core.domain.usecase.GetMyPredictionsUseCase
 import every.lol.com.core.domain.usecase.GetProfileUseCase
 import every.lol.com.core.domain.usecase.GetReadPostUseCase
 import every.lol.com.core.domain.usecase.GetSetPogCandidateUseCase
@@ -55,6 +54,9 @@ import every.lol.com.core.domain.usecase.SignupUseCase
 import every.lol.com.core.domain.usecase.SocialLoginUseCase
 import every.lol.com.core.domain.usecase.WithdrawalUseCase
 import every.lol.com.core.domain.usecase.aboutlck.GetAboutLCKMatchUseCase
+import every.lol.com.core.domain.usecase.mypage.GetMyPogUseCase
+import every.lol.com.core.domain.usecase.mypage.GetMyPomUseCase
+import every.lol.com.core.domain.usecase.mypage.GetMyPredictionsUseCase
 import every.lol.com.core.network.datasource.AboutLCKDataSource
 import every.lol.com.core.network.datasource.AuthDataSource
 import every.lol.com.core.network.datasource.CommunityDataSource
@@ -142,6 +144,8 @@ val appDependenciesModule = module {
     factory { GetSetPogCandidateUseCase(get()) }
     factory { GetAboutLCKMatchUseCase(get())  }
     factory { GetMyPredictionsUseCase(get()) }
+    factory { GetMyPogUseCase(get()) }
+    factory { GetMyPomUseCase(get()) }
 
     factoryOf(::IntroViewModel)
     factoryOf(::HomeViewModel)

--- a/core/data/src/commonMain/kotlin/every/lol/com/core/data/repository/MyPageRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/every/lol/com/core/data/repository/MyPageRepositoryImpl.kt
@@ -8,6 +8,10 @@ import every.lol.com.core.model.CommentsDetail
 import every.lol.com.core.model.Posts
 import every.lol.com.core.model.PostsDetail
 import every.lol.com.core.model.UserInform
+import every.lol.com.core.model.mypage.MypagePog
+import every.lol.com.core.model.mypage.MypagePogDetail
+import every.lol.com.core.model.mypage.MypagePom
+import every.lol.com.core.model.mypage.MypagePomDetail
 import every.lol.com.core.model.mypage.MypagePredictionDetail
 import every.lol.com.core.model.mypage.MypagePredictions
 import every.lol.com.core.network.datasource.MyPagesDataSource
@@ -116,4 +120,36 @@ class MyPageRepositoryImpl(
                 }
             )
         }
+
+    override suspend fun getPog(): Result<MypagePog> =
+        remote.getPog().toResult().map {
+            MypagePog(
+                setPogVoteDetails = it.setPogVoteDetails.map { detail ->
+                    MypagePogDetail(
+                        matchId = detail.matchId,
+                        setIndex = detail.setIndex,
+                        playerId = detail.playerId,
+                        playerName = detail.playerName,
+                        position = detail.position,
+                        voteDate = detail.voteDate
+                    )
+                }
+            )
+        }
+
+    override suspend fun getPom(): Result<MypagePom> =
+        remote.getPom().toResult().map {
+            MypagePom(
+                mvpVoteDetails = it.mvpVoteDetails.map {detail ->
+                    MypagePomDetail(
+                        matchId = detail.matchId,
+                        playerId = detail.playerId,
+                        playerName = detail.playerName,
+                        position = detail.position,
+                        voteDate = detail.voteDate
+                    )
+                }
+            )
+        }
+
 }

--- a/core/data/src/commonMain/kotlin/every/lol/com/core/data/repository/MyPageRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/every/lol/com/core/data/repository/MyPageRepositoryImpl.kt
@@ -8,6 +8,8 @@ import every.lol.com.core.model.CommentsDetail
 import every.lol.com.core.model.Posts
 import every.lol.com.core.model.PostsDetail
 import every.lol.com.core.model.UserInform
+import every.lol.com.core.model.mypage.MypagePredictionDetail
+import every.lol.com.core.model.mypage.MypagePredictions
 import every.lol.com.core.network.datasource.MyPagesDataSource
 import every.lol.com.core.network.model.request.PatchMyTeamRequest
 import every.lol.com.core.network.model.request.PatchProfileData
@@ -96,4 +98,22 @@ class MyPageRepositoryImpl(
             Unit
         }
     }
+
+    override suspend fun getPredictions(): Result<MypagePredictions> =
+        remote.getPredictions().toResult().map{
+            MypagePredictions(
+                correctCount = it.correctCount,
+                topPercent = it.topPercent,
+                predictionDetails = it.predictionDetails.map{detail ->
+                    MypagePredictionDetail(
+                        matchId = detail.matchId,
+                        matchDate = detail.matchDate,
+                        team1Name = detail.team1Name,
+                        team2Name = detail.team2Name,
+                        predictedTeamName = detail.predictedTeamName,
+                        isPredictionSuccessful = detail.isPredictionSuccessful
+                        )
+                }
+            )
+        }
 }

--- a/core/data/src/commonMain/kotlin/every/lol/com/core/data/repository/MyPageRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/every/lol/com/core/data/repository/MyPageRepositoryImpl.kt
@@ -111,7 +111,7 @@ class MyPageRepositoryImpl(
                 predictionDetails = it.predictionDetails.map{detail ->
                     MypagePredictionDetail(
                         matchId = detail.matchId,
-                        matchDate = detail.matchDate,
+                        matchDate = detail.matchDate.toFormattedDate() ,
                         team1Name = detail.team1Name,
                         team2Name = detail.team2Name,
                         predictedTeamName = detail.predictedTeamName,
@@ -131,7 +131,7 @@ class MyPageRepositoryImpl(
                         playerId = detail.playerId,
                         playerName = detail.playerName,
                         position = detail.position,
-                        voteDate = detail.voteDate
+                        voteDate = detail.voteDate.toFormattedDate()
                     )
                 }
             )
@@ -146,10 +146,20 @@ class MyPageRepositoryImpl(
                         playerId = detail.playerId,
                         playerName = detail.playerName,
                         position = detail.position,
-                        voteDate = detail.voteDate
+                        voteDate = detail.voteDate.toFormattedDate()
                     )
                 }
             )
         }
 
+}
+
+private fun String.toFormattedDate(): String {
+    return try {
+        val datePart = this.split("T")[0]
+        val parts = datePart.split("-")
+        "${parts[0].substring(2)}.${parts[1]}.${parts[2]}"
+    } catch (e: Exception) {
+        this
+    }
 }

--- a/core/domain/src/commonMain/kotlin/every/lol/com/core/domain/repository/MyPagesRepository.kt
+++ b/core/domain/src/commonMain/kotlin/every/lol/com/core/domain/repository/MyPagesRepository.kt
@@ -3,6 +3,8 @@ package every.lol.com.core.domain.repository
 import every.lol.com.core.model.Comments
 import every.lol.com.core.model.Posts
 import every.lol.com.core.model.UserInform
+import every.lol.com.core.model.mypage.MypagePog
+import every.lol.com.core.model.mypage.MypagePom
 import every.lol.com.core.model.mypage.MypagePredictions
 
 interface MyPagesRepository {
@@ -14,4 +16,6 @@ interface MyPagesRepository {
     suspend fun withdrawal(): Result<Unit?>
     suspend fun logout(): Result<Unit?>
     suspend fun getPredictions(): Result<MypagePredictions>
+    suspend fun getPog(): Result<MypagePog>
+    suspend fun getPom(): Result<MypagePom>
 }

--- a/core/domain/src/commonMain/kotlin/every/lol/com/core/domain/repository/MyPagesRepository.kt
+++ b/core/domain/src/commonMain/kotlin/every/lol/com/core/domain/repository/MyPagesRepository.kt
@@ -3,6 +3,7 @@ package every.lol.com.core.domain.repository
 import every.lol.com.core.model.Comments
 import every.lol.com.core.model.Posts
 import every.lol.com.core.model.UserInform
+import every.lol.com.core.model.mypage.MypagePredictions
 
 interface MyPagesRepository {
     suspend fun getProfile(): Result<UserInform>
@@ -12,4 +13,5 @@ interface MyPagesRepository {
     suspend fun getComments(page: Int): Result<Comments>
     suspend fun withdrawal(): Result<Unit?>
     suspend fun logout(): Result<Unit?>
+    suspend fun getPredictions(): Result<MypagePredictions>
 }

--- a/core/domain/src/commonMain/kotlin/every/lol/com/core/domain/usecase/GetMyPredictionsUseCase.kt
+++ b/core/domain/src/commonMain/kotlin/every/lol/com/core/domain/usecase/GetMyPredictionsUseCase.kt
@@ -1,0 +1,12 @@
+package every.lol.com.core.domain.usecase
+
+import every.lol.com.core.domain.repository.MyPagesRepository
+import every.lol.com.core.model.mypage.MypagePredictions
+
+
+class GetMyPredictionsUseCase(
+    private val myPagesRepository: MyPagesRepository
+) {
+    suspend operator fun invoke(): Result<MypagePredictions> =
+        myPagesRepository.getPredictions()
+}

--- a/core/domain/src/commonMain/kotlin/every/lol/com/core/domain/usecase/mypage/GetMyPogUseCase.kt
+++ b/core/domain/src/commonMain/kotlin/every/lol/com/core/domain/usecase/mypage/GetMyPogUseCase.kt
@@ -1,0 +1,11 @@
+package every.lol.com.core.domain.usecase.mypage
+
+import every.lol.com.core.domain.repository.MyPagesRepository
+import every.lol.com.core.model.mypage.MypagePog
+
+class GetMyPogUseCase(
+    private val myPagesRepository: MyPagesRepository
+) {
+    suspend operator fun invoke(): Result<MypagePog> =
+        myPagesRepository.getPog()
+}

--- a/core/domain/src/commonMain/kotlin/every/lol/com/core/domain/usecase/mypage/GetMyPomUseCase.kt
+++ b/core/domain/src/commonMain/kotlin/every/lol/com/core/domain/usecase/mypage/GetMyPomUseCase.kt
@@ -1,0 +1,12 @@
+package every.lol.com.core.domain.usecase.mypage
+
+import every.lol.com.core.domain.repository.MyPagesRepository
+import every.lol.com.core.model.mypage.MypagePog
+import every.lol.com.core.model.mypage.MypagePom
+
+class GetMyPomUseCase(
+    private val myPagesRepository: MyPagesRepository
+) {
+    suspend operator fun invoke(): Result<MypagePom> =
+        myPagesRepository.getPom()
+}

--- a/core/domain/src/commonMain/kotlin/every/lol/com/core/domain/usecase/mypage/GetMyPredictionsUseCase.kt
+++ b/core/domain/src/commonMain/kotlin/every/lol/com/core/domain/usecase/mypage/GetMyPredictionsUseCase.kt
@@ -1,8 +1,7 @@
-package every.lol.com.core.domain.usecase
+package every.lol.com.core.domain.usecase.mypage
 
 import every.lol.com.core.domain.repository.MyPagesRepository
 import every.lol.com.core.model.mypage.MypagePredictions
-
 
 class GetMyPredictionsUseCase(
     private val myPagesRepository: MyPagesRepository

--- a/core/model/src/commonMain/kotlin/every/lol/com/core/model/mypage/MypagePog.kt
+++ b/core/model/src/commonMain/kotlin/every/lol/com/core/model/mypage/MypagePog.kt
@@ -1,0 +1,15 @@
+package every.lol.com.core.model.mypage
+
+
+data class MypagePog(
+    val setPogVoteDetails: List<MypagePogDetail>
+)
+
+data class MypagePogDetail(
+    val matchId: Int,
+    val setIndex: Int,
+    val playerId: Int,
+    val playerName: String,
+    val position: String,
+    val voteDate: String
+)

--- a/core/model/src/commonMain/kotlin/every/lol/com/core/model/mypage/MypagePom.kt
+++ b/core/model/src/commonMain/kotlin/every/lol/com/core/model/mypage/MypagePom.kt
@@ -1,0 +1,14 @@
+package every.lol.com.core.model.mypage
+
+
+data class MypagePom(
+    val mvpVoteDetails: List<MypagePomDetail>
+)
+
+data class MypagePomDetail(
+    val matchId: Int,
+    val playerId: Int,
+    val playerName: String,
+    val position: String,
+    val voteDate: String
+)

--- a/core/model/src/commonMain/kotlin/every/lol/com/core/model/mypage/MypagePredictions.kt
+++ b/core/model/src/commonMain/kotlin/every/lol/com/core/model/mypage/MypagePredictions.kt
@@ -1,0 +1,16 @@
+package every.lol.com.core.model.mypage
+
+data class MypagePredictions(
+    val correctCount: Int,
+    val topPercent: Double,
+    val predictionDetails: List<MypagePredictionDetail>
+)
+
+data class MypagePredictionDetail(
+    val matchId: Int,
+    val matchDate: String,
+    val team1Name: String,
+    val team2Name: String,
+    val predictedTeamName: String,
+    val isPredictionSuccessful: Boolean
+)

--- a/core/network/src/commonMain/kotlin/every/lol/com/core/network/datasource/MyPagesDataSource.kt
+++ b/core/network/src/commonMain/kotlin/every/lol/com/core/network/datasource/MyPagesDataSource.kt
@@ -7,6 +7,7 @@ import every.lol.com.core.network.model.response.CommentsResponse
 import every.lol.com.core.network.model.response.PatchProfileResponse
 import every.lol.com.core.network.model.response.PostsResponse
 import every.lol.com.core.network.model.response.ProfileResponse
+import every.lol.com.core.network.model.response.mypage.GetPredictionsRespponse
 
 interface MyPagesDataSource {
     suspend fun getProfile(): ApiResponse<ProfileResponse>
@@ -16,4 +17,5 @@ interface MyPagesDataSource {
     suspend fun getComments(page: Int, size: Int):ApiResponse<CommentsResponse>
     suspend fun withdrawal(): ApiResponse<Unit?>
     suspend fun logout(refreshToken: String): ApiResponse<Unit?>
+    suspend fun getPredictions(): ApiResponse<GetPredictionsRespponse>
 }

--- a/core/network/src/commonMain/kotlin/every/lol/com/core/network/datasource/MyPagesDataSource.kt
+++ b/core/network/src/commonMain/kotlin/every/lol/com/core/network/datasource/MyPagesDataSource.kt
@@ -7,6 +7,8 @@ import every.lol.com.core.network.model.response.CommentsResponse
 import every.lol.com.core.network.model.response.PatchProfileResponse
 import every.lol.com.core.network.model.response.PostsResponse
 import every.lol.com.core.network.model.response.ProfileResponse
+import every.lol.com.core.network.model.response.mypage.GetPogResponse
+import every.lol.com.core.network.model.response.mypage.GetPomResponse
 import every.lol.com.core.network.model.response.mypage.GetPredictionsRespponse
 
 interface MyPagesDataSource {
@@ -18,4 +20,6 @@ interface MyPagesDataSource {
     suspend fun withdrawal(): ApiResponse<Unit?>
     suspend fun logout(refreshToken: String): ApiResponse<Unit?>
     suspend fun getPredictions(): ApiResponse<GetPredictionsRespponse>
+    suspend fun getPog(): ApiResponse<GetPogResponse>
+    suspend fun getPom(): ApiResponse<GetPomResponse>
 }

--- a/core/network/src/commonMain/kotlin/every/lol/com/core/network/model/response/mypage/GetPogResponse.kt
+++ b/core/network/src/commonMain/kotlin/every/lol/com/core/network/model/response/mypage/GetPogResponse.kt
@@ -1,0 +1,19 @@
+package every.lol.com.core.network.model.response.mypage
+
+import kotlinx.serialization.Serializable
+
+
+@Serializable
+data class GetPogResponse(
+    val setPogVoteDetails: List<GetSetPogVoteDetailResponse>
+)
+
+@Serializable
+data class GetSetPogVoteDetailResponse(
+    val matchId: Int,
+    val setIndex: Int,
+    val playerId: Int,
+    val playerName: String,
+    val position: String,
+    val voteDate: String
+)

--- a/core/network/src/commonMain/kotlin/every/lol/com/core/network/model/response/mypage/GetPomResponse.kt
+++ b/core/network/src/commonMain/kotlin/every/lol/com/core/network/model/response/mypage/GetPomResponse.kt
@@ -1,0 +1,18 @@
+package every.lol.com.core.network.model.response.mypage
+
+import kotlinx.serialization.Serializable
+
+
+@Serializable
+data class GetPomResponse(
+    val mvpVoteDetails: List<GetMvpVoteDetailResponse>
+)
+
+@Serializable
+data class GetMvpVoteDetailResponse(
+    val matchId: Int,
+    val playerId: Int,
+    val playerName: String,
+    val position: String,
+    val voteDate: String
+)

--- a/core/network/src/commonMain/kotlin/every/lol/com/core/network/model/response/mypage/GetPredictionsRespponse.kt
+++ b/core/network/src/commonMain/kotlin/every/lol/com/core/network/model/response/mypage/GetPredictionsRespponse.kt
@@ -1,0 +1,21 @@
+package every.lol.com.core.network.model.response.mypage
+
+import kotlinx.serialization.Serializable
+
+
+@Serializable
+data class GetPredictionsRespponse(
+    val correctCount: Int,
+    val topPercent: Double,
+    val predictionDetails: List<GetPredictionDetailResponse>
+)
+
+@Serializable
+data class GetPredictionDetailResponse(
+    val matchId: Int,
+    val matchDate: String,
+    val team1Name: String,
+    val team2Name: String,
+    val predictedTeamName: String,
+    val isPredictionSuccessful: Boolean
+)

--- a/core/network/src/commonMain/kotlin/every/lol/com/core/network/remote/MyPagesDataSourceImpl.kt
+++ b/core/network/src/commonMain/kotlin/every/lol/com/core/network/remote/MyPagesDataSourceImpl.kt
@@ -8,6 +8,8 @@ import every.lol.com.core.network.model.response.CommentsResponse
 import every.lol.com.core.network.model.response.PatchProfileResponse
 import every.lol.com.core.network.model.response.PostsResponse
 import every.lol.com.core.network.model.response.ProfileResponse
+import every.lol.com.core.network.model.response.mypage.GetPogResponse
+import every.lol.com.core.network.model.response.mypage.GetPomResponse
 import every.lol.com.core.network.model.response.mypage.GetPredictionsRespponse
 import every.lol.com.core.network.util.asApiResponse
 import io.ktor.client.HttpClient
@@ -96,4 +98,13 @@ class MyPagesDataSourceImpl(
     override suspend fun getPredictions(): ApiResponse<GetPredictionsRespponse> = runCatching {
         httpClient.get("/my-pages/votes/predictions")
     }.asApiResponse()
+
+    override suspend fun getPog(): ApiResponse<GetPogResponse> = runCatching {
+        httpClient.get("/my-pages/votes/set-pog")
+    }.asApiResponse()
+
+    override suspend fun getPom(): ApiResponse<GetPomResponse> = runCatching {
+        httpClient.get("/my-pages/votes/mvp")
+    }.asApiResponse()
+
 }

--- a/core/network/src/commonMain/kotlin/every/lol/com/core/network/remote/MyPagesDataSourceImpl.kt
+++ b/core/network/src/commonMain/kotlin/every/lol/com/core/network/remote/MyPagesDataSourceImpl.kt
@@ -104,7 +104,7 @@ class MyPagesDataSourceImpl(
     }.asApiResponse()
 
     override suspend fun getPom(): ApiResponse<GetPomResponse> = runCatching {
-        httpClient.get("/my-pages/votes/mvp")
+        httpClient.get("/my-pages/votes/mvps")
     }.asApiResponse()
 
 }

--- a/core/network/src/commonMain/kotlin/every/lol/com/core/network/remote/MyPagesDataSourceImpl.kt
+++ b/core/network/src/commonMain/kotlin/every/lol/com/core/network/remote/MyPagesDataSourceImpl.kt
@@ -8,6 +8,7 @@ import every.lol.com.core.network.model.response.CommentsResponse
 import every.lol.com.core.network.model.response.PatchProfileResponse
 import every.lol.com.core.network.model.response.PostsResponse
 import every.lol.com.core.network.model.response.ProfileResponse
+import every.lol.com.core.network.model.response.mypage.GetPredictionsRespponse
 import every.lol.com.core.network.util.asApiResponse
 import io.ktor.client.HttpClient
 import io.ktor.client.request.delete
@@ -90,5 +91,9 @@ class MyPagesDataSourceImpl(
                 append("Refresh", refreshToken)
             }
         }
+    }.asApiResponse()
+
+    override suspend fun getPredictions(): ApiResponse<GetPredictionsRespponse> = runCatching {
+        httpClient.get("/my-pages/votes/predictions")
     }.asApiResponse()
 }

--- a/feature/mypage/src/commonMain/kotlin/every/lol/com/feature/mypage/MypagePredictionScreen.kt
+++ b/feature/mypage/src/commonMain/kotlin/every/lol/com/feature/mypage/MypagePredictionScreen.kt
@@ -112,6 +112,7 @@ fun MypagePredictionScreen(
                             verticalAlignment = Alignment.Bottom
                         ) {
                             Text(
+                                modifier = Modifier.padding(bottom = 4.dp),
                                 text = "TOP",
                                 style = EveryLoLTheme.typography.pretendardBody01,
                                 color = EveryLoLTheme.color.community600

--- a/feature/mypage/src/commonMain/kotlin/every/lol/com/feature/mypage/MypagePredictionScreen.kt
+++ b/feature/mypage/src/commonMain/kotlin/every/lol/com/feature/mypage/MypagePredictionScreen.kt
@@ -50,7 +50,8 @@ fun MypagePredictionScreen(
 ){
     val snackbarHostState = remember { SnackbarHostState() }
     val predictionState = state as? MypageUiState.Prediction
-    val rank = 10
+    val rank = predictionState?.rank ?: 0
+
     val rankImage = when {
         rank <= 1 -> Res.drawable.img_top_001
         rank <= 3 -> Res.drawable.img_top_003
@@ -63,6 +64,7 @@ fun MypagePredictionScreen(
         rank <= 90 -> Res.drawable.img_top_090
         else -> Res.drawable.img_top_100
     }
+
     Box(modifier = Modifier.fillMaxSize()) {
         Scaffold(
             modifier = Modifier
@@ -134,13 +136,15 @@ fun MypagePredictionScreen(
                         .padding(top=12.dp)
                 ) {
                     predictionState?.let { data ->
-                        if (data.predictions.isEmpty()) {
+                        val predictionList = data.data ?: emptyList()
+
+                        if (predictionList.isEmpty()) {
                             DefaultScreen(
                                 title = "투표 내역이 아직 없습니다",
                                 description = "첫 승부 예측 투표를 해보세요"
                             )
                         } else {
-                            data.predictions.forEach { prediction ->
+                            predictionList.forEach { prediction ->
                                 Predictions(prediction = prediction)
                             }
                         }

--- a/feature/mypage/src/commonMain/kotlin/every/lol/com/feature/mypage/MypageViewModel.kt
+++ b/feature/mypage/src/commonMain/kotlin/every/lol/com/feature/mypage/MypageViewModel.kt
@@ -3,13 +3,15 @@ package every.lol.com.feature.mypage
 import every.lol.com.core.common.compressImage
 import every.lol.com.core.domain.usecase.GetMyCommentsUseCase
 import every.lol.com.core.domain.usecase.GetMyPostsUseCase
-import every.lol.com.core.domain.usecase.GetMyPredictionsUseCase
 import every.lol.com.core.domain.usecase.GetProfileUseCase
 import every.lol.com.core.domain.usecase.LogoutUseCase
 import every.lol.com.core.domain.usecase.NicknameUseCase
 import every.lol.com.core.domain.usecase.PatchMyTeamUseCase
 import every.lol.com.core.domain.usecase.PatchProfileUseCase
 import every.lol.com.core.domain.usecase.WithdrawalUseCase
+import every.lol.com.core.domain.usecase.mypage.GetMyPogUseCase
+import every.lol.com.core.domain.usecase.mypage.GetMyPomUseCase
+import every.lol.com.core.domain.usecase.mypage.GetMyPredictionsUseCase
 import every.lol.com.core.model.Team
 import every.lol.com.feature.mypage.model.MypageIntent
 import every.lol.com.feature.mypage.model.MypageUiState
@@ -52,8 +54,10 @@ class MypageViewModel(
     private val getMyCommentsUseCase: GetMyCommentsUseCase,
     private val logoutUseCase: LogoutUseCase,
     private val withdrawalUseCase: WithdrawalUseCase,
-    private val getMyPredictionsUseCase: GetMyPredictionsUseCase
-) : ViewModel() {
+    private val getMyPredictionsUseCase: GetMyPredictionsUseCase,
+    private val getMyPomUseCase: GetMyPomUseCase,
+    private val getMyPogUseCase: GetMyPogUseCase,
+    ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<MypageUiState>(MypageUiState.Loading)
     val uiState = _uiState.asStateFlow()
@@ -342,6 +346,7 @@ class MypageViewModel(
                 mvpList = dummyMvpList,
                 isLoading = false
             )
+
         }
     }
 

--- a/feature/mypage/src/commonMain/kotlin/every/lol/com/feature/mypage/MypageViewModel.kt
+++ b/feature/mypage/src/commonMain/kotlin/every/lol/com/feature/mypage/MypageViewModel.kt
@@ -328,25 +328,32 @@ class MypageViewModel(
     private fun loadMVPData() {
         _uiState.value = MypageUiState.MVP(isLoading = true)
         viewModelScope.launch {
-            val dummyMvpList = listOf(
-                MypageUiState.MVPItem(
-                    id = 1,
-                    matchDate = "2024.03.15",
-                    playerName = "Faker",
-                    playerTeam = 1
-                ),
-                MypageUiState.MVPItem(
-                    id = 2,
-                    matchDate = "2024.03.14",
-                    playerName = "Chovy",
-                    playerTeam = 2
+            getMyPomUseCase().onSuccess { response ->
+                _uiState.value = MypageUiState.MVP(
+                    mvpList = response.mvpVoteDetails.map { detail ->
+                        MypageUiState.MVPItem(
+                            detail.matchId,
+                            detail.voteDate,
+                            detail.playerName,
+                            detail.playerId
+                        )
+                    },
+                    isLoading = false
                 )
-            )
-            _uiState.value = MypageUiState.MVP(
-                mvpList = dummyMvpList,
-                isLoading = false
-            )
-
+            }
+            getMyPogUseCase().onSuccess { response ->
+                _uiState.value = MypageUiState.MVP(
+                    mvpList = response.setPogVoteDetails.map { detail ->
+                        MypageUiState.MVPItem(
+                            detail.matchId,
+                            detail.voteDate,
+                            detail.playerName,
+                            detail.playerId
+                        )
+                    },
+                    isLoading = false
+                )
+            }
         }
     }
 

--- a/feature/mypage/src/commonMain/kotlin/every/lol/com/feature/mypage/MypageViewModel.kt
+++ b/feature/mypage/src/commonMain/kotlin/every/lol/com/feature/mypage/MypageViewModel.kt
@@ -3,6 +3,7 @@ package every.lol.com.feature.mypage
 import every.lol.com.core.common.compressImage
 import every.lol.com.core.domain.usecase.GetMyCommentsUseCase
 import every.lol.com.core.domain.usecase.GetMyPostsUseCase
+import every.lol.com.core.domain.usecase.GetMyPredictionsUseCase
 import every.lol.com.core.domain.usecase.GetProfileUseCase
 import every.lol.com.core.domain.usecase.LogoutUseCase
 import every.lol.com.core.domain.usecase.NicknameUseCase
@@ -50,7 +51,8 @@ class MypageViewModel(
     private val getMyPostsUseCase: GetMyPostsUseCase,
     private val getMyCommentsUseCase: GetMyCommentsUseCase,
     private val logoutUseCase: LogoutUseCase,
-    private val withdrawalUseCase: WithdrawalUseCase
+    private val withdrawalUseCase: WithdrawalUseCase,
+    private val getMyPredictionsUseCase: GetMyPredictionsUseCase
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<MypageUiState>(MypageUiState.Loading)
@@ -346,29 +348,23 @@ class MypageViewModel(
     private fun loadPredictionData() {
         _uiState.value = MypageUiState.Prediction(isLoading = true)
         viewModelScope.launch {
-            val dummyPredictions = listOf(
-                MypageUiState.PredictionItem(
-                    id = 101,
-                    matchDate = "2024.03.16",
-                    homeTeamId = 3, // T1
-                    awayTeamId = 2, // GEN
-                    myVoteTeamId = 3, // 내가 T1 투표
-                    winnerTeamId = 3,
-                ),
-                MypageUiState.PredictionItem(
-                    id = 102,
-                    matchDate = "2024.03.17",
-                    homeTeamId = 1, // HLE
-                    awayTeamId = 10, // KT
-                    myVoteTeamId = 1, // 내가 HLE 투표
-                    winnerTeamId = null,
+            getMyPredictionsUseCase().onSuccess { response ->
+                _uiState.value = MypageUiState.Prediction(
+                    rank = response.topPercent.toInt(),
+                    data = response.predictionDetails.map { detail ->
+                        MypageUiState.PredictionItem(
+                            detail.matchId,
+                            detail.matchDate,
+                            detail.team1Name,
+                            detail.team2Name,
+                            detail.predictedTeamName,
+                            detail.isPredictionSuccessful
+                        ) },
+                    isLoading = false
                 )
-            )
-            _uiState.value = MypageUiState.Prediction(
-                rank = 10,
-                predictions = dummyPredictions,
-                isLoading = false
-            )
+            }.onFailure { error ->
+                _event.emit(MypageEvent.ShowErrorSnackbar(error))
+            }
         }
     }
 

--- a/feature/mypage/src/commonMain/kotlin/every/lol/com/feature/mypage/component/PredictionItem.kt
+++ b/feature/mypage/src/commonMain/kotlin/every/lol/com/feature/mypage/component/PredictionItem.kt
@@ -18,12 +18,19 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import every.lol.com.core.designsystem.theme.EveryLoLTheme
 import every.lol.com.core.model.Team
+import every.lol.com.core.model.Team.Companion.fromTeamName
 import every.lol.com.feature.mypage.model.MypageUiState
 
 @Composable
 fun Predictions(
     prediction: MypageUiState.PredictionItem
 ) {
+    val winnerTeamName = if (prediction.isPredictionSuccessful) {
+        prediction.predictionTeamName
+    } else {
+        if (prediction.predictionTeamName == prediction.team1Name) prediction.team2Name else prediction.team1Name
+    }
+
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -49,9 +56,9 @@ fun Predictions(
                 ){
                     TeamText(
                         modifier = Modifier.padding(bottom=4.dp),
-                        teamId = prediction.awayTeamId,
-                        isWinner = prediction.homeTeamId == prediction.winnerTeamId,
-                        isMyVote = prediction.homeTeamId == prediction.myVoteTeamId
+                        teamId = fromTeamName(prediction.team1Name).id,
+                        isWinner = prediction.team1Name == winnerTeamName,
+                        isMyVote = prediction.team1Name == prediction.predictionTeamName
                     )
 
                     Text(
@@ -61,9 +68,9 @@ fun Predictions(
                     )
 
                     TeamText(
-                        teamId = prediction.homeTeamId,
-                        isWinner = prediction.awayTeamId == prediction.winnerTeamId,
-                        isMyVote = prediction.awayTeamId == prediction.myVoteTeamId
+                        teamId =  fromTeamName(prediction.team2Name).id,
+                        isWinner = prediction.team2Name == winnerTeamName,
+                        isMyVote = prediction.team2Name == prediction.predictionTeamName
                     )
                 }
                 Text(
@@ -71,14 +78,14 @@ fun Predictions(
                         .clip(RoundedCornerShape(4.dp))
                         .border(
                             width = 1.dp,
-                            color = if(prediction.myVoteTeamId == prediction.winnerTeamId) EveryLoLTheme.color.semanticCheck else EveryLoLTheme.color.grayScale800,
+                            color = if(prediction.isPredictionSuccessful) EveryLoLTheme.color.semanticCheck else EveryLoLTheme.color.grayScale800,
                             shape = RoundedCornerShape(4.dp)
                         )
                         .background(EveryLoLTheme.color.grayScale1000)
                         .padding(4.dp),
-                    text = if(prediction.myVoteTeamId == prediction.winnerTeamId) "예측 성공" else "예측 실패",
+                    text = if(prediction.isPredictionSuccessful) "예측 성공" else "예측 실패",
                     style = EveryLoLTheme.typography.label03,
-                    color = if(prediction.myVoteTeamId == prediction.winnerTeamId) EveryLoLTheme.color.white200 else EveryLoLTheme.color.gray800
+                    color = if(prediction.isPredictionSuccessful) EveryLoLTheme.color.white200 else EveryLoLTheme.color.gray800
                 )
             }
             HorizontalDivider(

--- a/feature/mypage/src/commonMain/kotlin/every/lol/com/feature/mypage/model/MypageUiModel.kt
+++ b/feature/mypage/src/commonMain/kotlin/every/lol/com/feature/mypage/model/MypageUiModel.kt
@@ -13,7 +13,7 @@ sealed interface MypageUiState {
     ): MypageUiState
     data class Prediction(
         val rank: Int = 0,
-        val predictions: List<PredictionItem> = emptyList(),
+        val data: List<PredictionItem>?= null,
         val isLoading: Boolean = false
     ) : MypageUiState
 
@@ -30,12 +30,12 @@ sealed interface MypageUiState {
     )
 
     data class PredictionItem(
-        val id: Int,
+        val matchId: Int,
         val matchDate: String,
-        val homeTeamId: Int,
-        val awayTeamId: Int,
-        val winnerTeamId: Int?,
-        val myVoteTeamId: Int,
+        val team1Name: String,
+        val team2Name: String,
+        val predictionTeamName: String,
+        val isPredictionSuccessful: Boolean
     )
 
     data class Community(


### PR DESCRIPTION
- closed #80 

## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 마이페이지에 예측 데이터 로드 및 표시 (정답률, 순위 포함)
  * POG(세트 최고 선수) 투표 데이터 조회 기능 추가
  * MVP 투표 데이터 조회 기능 추가
  * 실제 팀 이름과 투표 결과 상태를 기반으로 예측 정보 표시

* **개선사항**
  * 마이페이지 UI 모델 업데이트로 동적 데이터 처리 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->