### PR TITLE
[FIX/#82] 승부예측 결과 수정

### DIFF
--- a/feature/home/src/commonMain/kotlin/every/lol/com/feature/home/HomeScreen.kt
+++ b/feature/home/src/commonMain/kotlin/every/lol/com/feature/home/HomeScreen.kt
@@ -130,6 +130,7 @@ fun HomeScreen(
 
             MatchCardRow(
                 matchCards = matchData,
+                matchRate = homeState?.matchRates ?: emptyMap(),
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(vertical = 24.dp)

--- a/feature/home/src/commonMain/kotlin/every/lol/com/feature/home/component/MatchCard.kt
+++ b/feature/home/src/commonMain/kotlin/every/lol/com/feature/home/component/MatchCard.kt
@@ -132,8 +132,21 @@ fun MatchCard(
         return
     }
 
-    val team1Progress = voteRate?.team1?.voteRate?.toFloat()?.div(100f) ?: 0.5f
-    val team2Progress = voteRate?.team2?.voteRate?.toFloat()?.div(100f) ?: 0.5f
+    val minVisibleProgress = 0.1f
+
+    val team1Progress = when {
+        voteRate == null -> 0.5f
+        voteRate.totalVoteCount == 0 -> 0.5f
+        voteRate.team1.voteRate == 0.0 -> minVisibleProgress
+        else -> (voteRate.team1.voteRate.toFloat() / 100f).coerceIn(minVisibleProgress, 1f)
+    }
+
+    val team2Progress = when {
+        voteRate == null -> 0.5f
+        voteRate.totalVoteCount == 0 -> 0.5f
+        voteRate.team2.voteRate == 0.0 -> minVisibleProgress
+        else -> (voteRate.team2.voteRate.toFloat() / 100f).coerceIn(minVisibleProgress, 1f)
+    }
 
     val statusColor = when(matchCard.matchStatus){
         "LIVE" -> EveryLoLTheme.color.semanticWarning

--- a/feature/matches/src/commonMain/kotlin/every/lol/com/feature/matches/component/DetailMatchCard.kt
+++ b/feature/matches/src/commonMain/kotlin/every/lol/com/feature/matches/component/DetailMatchCard.kt
@@ -39,10 +39,8 @@ fun DetailMatchCard(
     onOpenTalkClick: () -> Unit = {},
     onPredictionClick: () -> Unit = {}
 ) {
-    val displayWinnerTeamName = when (item.matchStatus) {
-        MatchStatus.FINISHED -> item.actualWinnerTeamName
-        else -> item.predictedWinnerTeamName
-    }
+    val displayWinnerTeamName = item.actualWinnerTeamName
+
     Column(
         modifier = modifier
             .width(328.dp)


### PR DESCRIPTION
- closed #82 

## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
경기 결과과 자신이 투표한 팀의 승리로 표시되던 현상 수정
홈 화면에서 승부 예측 투표율이 막대에 반영되지 않는 현상 수정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **버그 수정**
  * 경기 카드의 진행률 표시줄이 더 안정적으로 표시됩니다.
  * 경기 상세 정보에서 우승팀 표시가 일관되게 표시됩니다.

* **개선**
  * 경기 카드에 매치율 정보가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->