### PR TITLE
[Feat/#86] 게시글 수정 구현

### DIFF
--- a/composeApp/src/commonMain/kotlin/every/lol/com/App.kt
+++ b/composeApp/src/commonMain/kotlin/every/lol/com/App.kt
@@ -178,7 +178,7 @@ fun App() {
                             navController.navigate(Route.Read(postId))
                         },
                         onWriteClick = {
-                            navController.navigate(Route.Write)
+                            navController.navigate(Route.Write())
                         }
                     )
 
@@ -186,6 +186,9 @@ fun App() {
                         innerPadding = innerPadding,
                         onBackClick = {
                             navController.popBackStack()
+                        },
+                        onEditClick = { postId ->
+                            navController.navigate(Route.Write(postId))
                         }
                     )
 

--- a/composeApp/src/commonMain/kotlin/every/lol/com/di/Koin.kt
+++ b/composeApp/src/commonMain/kotlin/every/lol/com/di/Koin.kt
@@ -40,6 +40,7 @@ import every.lol.com.core.domain.usecase.GetSetPogResultUseCase
 import every.lol.com.core.domain.usecase.GetSupportTeamUseCase
 import every.lol.com.core.domain.usecase.LogoutUseCase
 import every.lol.com.core.domain.usecase.NicknameUseCase
+import every.lol.com.core.domain.usecase.PatchCommunityPostUseCase
 import every.lol.com.core.domain.usecase.PatchMyTeamUseCase
 import every.lol.com.core.domain.usecase.PatchProfileUseCase
 import every.lol.com.core.domain.usecase.PostCommunityCommentUseCase
@@ -122,6 +123,7 @@ val appDependenciesModule = module {
     factory { GetCommunityPopularPostsUseCase(get()) }
     factory { GetReadPostUseCase(get())}
     factory { PostCommunityPostUseCase(get()) }
+    factory { PatchCommunityPostUseCase(get()) }
     factory { DeletePostUseCase(get()) }
     factory { ReportPostUseCase(get()) }
     factory { PostCommunityCommentUseCase(get()) }

--- a/core/data/src/commonMain/kotlin/every/lol/com/core/data/repository/CommunityRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/every/lol/com/core/data/repository/CommunityRepositoryImpl.kt
@@ -16,6 +16,9 @@ import every.lol.com.core.model.PostList
 import every.lol.com.core.model.PostListDetail
 import every.lol.com.core.network.datasource.CommunityDataSource
 import every.lol.com.core.network.model.request.BlocksRequest
+import every.lol.com.core.network.model.request.EditBlocksRequest
+import every.lol.com.core.network.model.request.EditPostDetailRequest
+import every.lol.com.core.network.model.request.EditPostRequest
 import every.lol.com.core.network.model.request.MediaFileRequst
 import every.lol.com.core.network.model.request.PostCommentRequest
 import every.lol.com.core.network.model.request.PostPostDetailRequest
@@ -68,8 +71,52 @@ class CommunityRepositoryImpl(
             .map { }
     }
 
-/*    override suspend fun editPost(postId: Int, type: String, title: String, content: String): Result<Unit> =
-        remote.editPost(postId, PostPostDetailRequest(type, title, blocks)).toResult().map{it.postId}*/
+    override suspend fun editPost(postId: Int, newFiles: List<MediaFile>?, type: String, title: String, blocks: List<PostBlock>): Result<Unit> {
+        val networkBlocks = blocks.mapIndexed { index, block ->
+            when (block) {
+                is PostBlock.Text -> EditBlocksRequest(
+                    sequence = index + 1,
+                    type = "TEXT",
+                    content = block.text
+                )
+                is PostBlock.Image -> {
+                    val isExisting = block.imageUrl.startsWith("http")
+                    EditBlocksRequest(
+                        sequence = index + 1,
+                        type = "IMAGE",
+                        fileIndex = if (!isExisting) newFiles?.indexOfFirst { it.uriString == block.imageUrl } else null,
+                        existingFileUrl = if (isExisting) block.imageUrl else null
+                    )
+                }
+                is PostBlock.Video -> {
+                    val isExisting = block.videoUrl.startsWith("http")
+                    EditBlocksRequest(
+                        sequence = index + 1,
+                        type = "VIDEO",
+                        fileIndex = if (!isExisting) newFiles?.indexOfFirst { it.uriString == block.videoUrl } else null,
+                        existingFileUrl = if (isExisting) block.videoUrl else null
+                    )
+                }
+            }
+        }
+
+        val networkNewFiles = newFiles?.map {
+            MediaFileRequst(uriString = it.uriString, isVideo = it.isVideo)
+        }
+
+        val requestBody = EditPostRequest(
+            newFiles = networkNewFiles,
+            request = EditPostDetailRequest(
+                postType = type,
+                postTitle = title,
+                blocks = networkBlocks
+            )
+        )
+
+        return remote.editPost(postId, requestBody)
+            .toResult()
+            .map { }
+    }
 
     override suspend fun detailPost(postId: Int): Result<PostDetail> =
         remote.detailPost(postId).toResult().map {response ->

--- a/core/domain/src/commonMain/kotlin/every/lol/com/core/domain/repository/CommunityRepository.kt
+++ b/core/domain/src/commonMain/kotlin/every/lol/com/core/domain/repository/CommunityRepository.kt
@@ -9,7 +9,7 @@ import every.lol.com.core.model.PostList
 
 interface CommunityRepository {
     suspend fun postPost(files: List<MediaFile>?=null, type: String, title: String, blocks: List<PostBlock>): Result<Unit>
-    //suspend fun editPost(postId: Int, type: String, title: String, content: String): Result<Unit>
+    suspend fun editPost(postId: Int, newFiles: List<MediaFile>?=null, type: String, title: String, blocks: List<PostBlock>): Result<Unit>
     suspend fun detailPost(postId: Int): Result<PostDetail>
     suspend fun postList(postType: String, page: Int, size: Int): Result<PostList>
     suspend fun popularPostList(period: String): Result<PopularPostList>

--- a/core/domain/src/commonMain/kotlin/every/lol/com/core/domain/usecase/PatchCommunityPostUseCase.kt
+++ b/core/domain/src/commonMain/kotlin/every/lol/com/core/domain/usecase/PatchCommunityPostUseCase.kt
@@ -1,0 +1,19 @@
+package every.lol.com.core.domain.usecase
+
+import every.lol.com.core.domain.repository.CommunityRepository
+import every.lol.com.core.model.MediaFile
+import every.lol.com.core.model.PostBlock
+
+
+class PatchCommunityPostUseCase(
+    private val communityRepository: CommunityRepository
+) {
+    suspend operator fun invoke(
+        postId: Int,
+        newFiles: List<MediaFile>? = null,
+        type: String,
+        title: String,
+        blocks: List<PostBlock>
+    ): Result<Unit> =
+        communityRepository.editPost(postId, newFiles, type, title, blocks)
+}

--- a/core/model/src/commonMain/kotlin/every/lol/com/core/model/PostBlock.kt
+++ b/core/model/src/commonMain/kotlin/every/lol/com/core/model/PostBlock.kt
@@ -13,9 +13,8 @@ sealed class PostBlock{
 }
 
 fun mapToUiState(serverPost: PostDetail): List<PostBlock> {
-    // 서버에서 준 blocks 리스트를 순회하며 PostBlock으로 변환
     return serverPost.blocks
-        .sortedBy { it.sequence } // 혹시 모르니 순서대로 정렬
+        .sortedBy { it.sequence }
         .mapNotNull { block ->
             when (block.type) {
                 "TEXT" -> {
@@ -30,7 +29,7 @@ fun mapToUiState(serverPost: PostDetail): List<PostBlock> {
                     block.fileUrl?.let {
                         PostBlock.Video(
                             videoUrl = it,
-                            thumbnailUrl = null // 서버에서 안 주므로 null 처리
+                            thumbnailUrl = null
                         )
                     }
                 }

--- a/core/navigation/src/commonMain/kotlin/every/lol/com/core/navigation/Route.kt
+++ b/core/navigation/src/commonMain/kotlin/every/lol/com/core/navigation/Route.kt
@@ -2,6 +2,7 @@ package every.lol.com.core.navigation
 
 import kotlinx.serialization.Serializable
 
+@Serializable
 sealed interface Route {
 
     @Serializable
@@ -23,7 +24,7 @@ sealed interface Route {
     data object Community : Route
 
     @Serializable
-    data object Write : Route
+    data class Write(val postId: Int? = null) : Route
 
     @Serializable
     data class Read(val postId: Int) : Route

--- a/core/network/src/commonMain/kotlin/every/lol/com/core/network/datasource/CommunityDataSource.kt
+++ b/core/network/src/commonMain/kotlin/every/lol/com/core/network/datasource/CommunityDataSource.kt
@@ -1,8 +1,8 @@
 package every.lol.com.core.network.datasource
 
 import every.lol.com.core.network.model.ApiResponse
+import every.lol.com.core.network.model.request.EditPostRequest
 import every.lol.com.core.network.model.request.PostCommentRequest
-import every.lol.com.core.network.model.request.PostPostDetailRequest
 import every.lol.com.core.network.model.request.PostPostRequest
 import every.lol.com.core.network.model.request.ReportCommentRequest
 import every.lol.com.core.network.model.request.ReportPostRequest
@@ -14,7 +14,7 @@ import every.lol.com.core.network.model.response.PostListResponse
 
 interface CommunityDataSource {
     suspend fun postPost(request: PostPostRequest): ApiResponse<PostIdResponse>
-    suspend fun editPost(postId: Int, request: PostPostDetailRequest): ApiResponse<PostIdResponse>
+    suspend fun editPost(postId: Int, request: EditPostRequest): ApiResponse<PostIdResponse>
     suspend fun detailPost(postId: Int): ApiResponse<PostDetailResponse>
     suspend fun postList(postType: String, page: Int, size: Int): ApiResponse<PostListResponse>
     suspend fun popularPostList(period: String): ApiResponse<PopularPostListResponse>

--- a/core/network/src/commonMain/kotlin/every/lol/com/core/network/model/request/EditPostRequest.kt
+++ b/core/network/src/commonMain/kotlin/every/lol/com/core/network/model/request/EditPostRequest.kt
@@ -3,9 +3,9 @@ package every.lol.com.core.network.model.request
 import kotlinx.serialization.Serializable
 
 data class EditPostRequest(
-    val newFiles: List<MediaFileRequst>?=null,
-    val request: EditPostDetailRequest
-)
+    val request: EditPostDetailRequest,
+    val newFiles: List<MediaFileRequst>?=null
+    )
 
 @Serializable
 data class EditPostDetailRequest(

--- a/core/network/src/commonMain/kotlin/every/lol/com/core/network/model/request/EditPostRequest.kt
+++ b/core/network/src/commonMain/kotlin/every/lol/com/core/network/model/request/EditPostRequest.kt
@@ -1,0 +1,24 @@
+package every.lol.com.core.network.model.request
+
+import kotlinx.serialization.Serializable
+
+data class EditPostRequest(
+    val newFiles: List<MediaFileRequst>?=null,
+    val request: EditPostDetailRequest
+)
+
+@Serializable
+data class EditPostDetailRequest(
+    val postType: String,
+    val postTitle: String,
+    val blocks: List<EditBlocksRequest>
+)
+
+@Serializable
+data class EditBlocksRequest(
+    val sequence: Int,
+    val type: String,
+    val content: String?=null,
+    val fileIndex: Int?=null,
+    val existingFileUrl: String?=null
+)

--- a/core/network/src/commonMain/kotlin/every/lol/com/core/network/remote/CommunityDataSourceImpl.kt
+++ b/core/network/src/commonMain/kotlin/every/lol/com/core/network/remote/CommunityDataSourceImpl.kt
@@ -3,8 +3,8 @@ package every.lol.com.core.network.remote
 import every.lol.com.core.common.openFileStream
 import every.lol.com.core.network.datasource.CommunityDataSource
 import every.lol.com.core.network.model.ApiResponse
+import every.lol.com.core.network.model.request.EditPostRequest
 import every.lol.com.core.network.model.request.PostCommentRequest
-import every.lol.com.core.network.model.request.PostPostDetailRequest
 import every.lol.com.core.network.model.request.PostPostRequest
 import every.lol.com.core.network.model.request.ReportCommentRequest
 import every.lol.com.core.network.model.request.ReportPostRequest
@@ -74,9 +74,43 @@ class CommunityDataSourceImpl(
          }
     }.asApiResponse()
 
-    override suspend fun editPost(postId: Int, request: PostPostDetailRequest): ApiResponse<PostIdResponse> = runCatching {
-        httpClient.patch("/post/$postId/modify"){
-            setBody(request)
+    override suspend fun editPost(postId: Int, request: EditPostRequest): ApiResponse<PostIdResponse> =
+        withContext(NonCancellable) {
+        runCatching {
+            val jsonString = Json.encodeToString(request.request)
+            httpClient.patch("/post/$postId/modify") {
+                timeout {
+                    requestTimeoutMillis = 300_000L
+                    connectTimeoutMillis = 30_000L
+                    socketTimeoutMillis = 300_000L
+                }
+
+                setBody(
+                    MultiPartFormDataContent(
+                        formData {
+                            append("request", jsonString, Headers.build {
+                                append(HttpHeaders.ContentType, "application/json")
+                            })
+                            request.newFiles?.forEachIndexed { index, mediaFile ->
+                                val contentType = if (mediaFile.isVideo) "video/mp4" else "image/jpeg"
+                                val extension = if (mediaFile.isVideo) "mp4" else "jpg"
+                                val fileName = "file_$index.$extension"
+
+                                appendInput(
+                                    key = "files",
+                                    headers = Headers.build {
+                                        append(HttpHeaders.ContentType, contentType)
+                                        append(HttpHeaders.ContentDisposition, "filename=\"$fileName\"")
+                                    },
+                                    block = {
+                                        openFileStream(platformContext, mediaFile.uriString)
+                                    }
+                                )
+                            }
+                        }
+                    )
+                )
+            }
         }
     }.asApiResponse()
 

--- a/core/network/src/commonMain/kotlin/every/lol/com/core/network/remote/CommunityDataSourceImpl.kt
+++ b/core/network/src/commonMain/kotlin/every/lol/com/core/network/remote/CommunityDataSourceImpl.kt
@@ -97,7 +97,7 @@ class CommunityDataSourceImpl(
                                 val fileName = "file_$index.$extension"
 
                                 appendInput(
-                                    key = "files",
+                                    key = "newFiles",
                                     headers = Headers.build {
                                         append(HttpHeaders.ContentType, contentType)
                                         append(HttpHeaders.ContentDisposition, "filename=\"$fileName\"")

--- a/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/CommunityViewModel.kt
+++ b/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/CommunityViewModel.kt
@@ -72,12 +72,16 @@ class CommunityViewModel(
     fun onIntent(intent: CommunityIntent){
         when(intent){
             is CommunityIntent.Loading -> {
-                if (_uiState.value is CommunityUiState.Write) return
+                val currentState = _uiState.value
+
+                 if (currentState is CommunityUiState.Write && !currentState.isLoading) {
+                    return
+                }
 
                 _uiState.value = CommunityUiState.Loading
+                isFetching = false // 플래그 초기화
                 loadCommunityData(tab = CommunityUiState.CommunityTab.ALL)
             }
-
             is CommunityIntent.ClickTab -> handleTabClick(intent.tab)
             is CommunityIntent.ClickWriteTab -> {
                 communityLoadJob?.cancel()
@@ -377,7 +381,7 @@ class CommunityViewModel(
         }
     }
 
-    private fun handleSavePost(title: String, content: String){
+    private fun handleSavePost(title: String, content: String) {
         val currentState = _uiState.value as? CommunityUiState.Write ?: return
         val isEditMode = currentState.postId != null
 
@@ -424,17 +428,23 @@ class CommunityViewModel(
                 }
 
                 result.onSuccess {
+                    _uiState.value = CommunityUiState.Loading
+                    isFetching = false
                     _event.emit(CommunityEvent.WriteSuccess)
+                    loadCommunityData(isNextPage = false)
                 }.onFailure { e ->
+                    println("DEBUG_LOG: 저장 실패 원인: ${e.message}")
                     _uiState.update { if (it is CommunityUiState.Write) it.copy(isLoading = false) else it }
                     _event.emit(CommunityEvent.ShowToast("저장에 실패했습니다: ${e.message}"))
                 }
             } catch (e: Exception) {
+                println("DEBUG_LOG: 예외 발생: ${e.stackTraceToString()}")
                 _uiState.update { if (it is CommunityUiState.Write) it.copy(isLoading = false) else it }
-                _event.emit(CommunityEvent.ShowToast("저장에 실패했습니다: ${e.message}"))
+                _event.emit(CommunityEvent.ShowToast("오류가 발생했습니다."))
             }
         }
     }
+
     private fun handleDeletePost(postId: Int) {
         viewModelScope.launch {
             deletePostUseCase(postId).onSuccess {

--- a/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/CommunityViewModel.kt
+++ b/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/CommunityViewModel.kt
@@ -71,7 +71,11 @@ class CommunityViewModel(
 
     fun onIntent(intent: CommunityIntent){
         when(intent){
-            CommunityIntent.Loading -> loadCommunityData(tab = CommunityUiState.CommunityTab.ALL)
+            is CommunityIntent.Loading -> {
+                _uiState.value = CommunityUiState.Community(isLoading = true)
+                loadCommunityData(tab = CommunityUiState.CommunityTab.ALL)
+            }
+
             is CommunityIntent.ClickTab -> handleTabClick(intent.tab)
             is CommunityIntent.ClickWriteTab -> {
                 communityLoadJob?.cancel()
@@ -199,7 +203,11 @@ class CommunityViewModel(
                         return@update state
                     }
 
-                    val currentState = state as? CommunityUiState.Community ?: CommunityUiState.Community()
+                    val currentState = when (state) {
+                        is CommunityUiState.Community -> state
+                        is CommunityUiState.Loading -> CommunityUiState.Community()
+                        else -> return@update state
+                    }
 
                     val updatedPosts = if (isNextPage) {
                         currentState.posts + response.postDetailList

--- a/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/CommunityViewModel.kt
+++ b/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/CommunityViewModel.kt
@@ -118,8 +118,11 @@ class CommunityViewModel(
             }
             is CommunityIntent.LoadPostForEdit -> {
                 val currentState = _uiState.value
-                if (currentState is CommunityUiState.Write && currentState.title.isNotEmpty()) {
-                    _uiState.update { currentState.copy(isLoading = false) }
+                if (currentState is CommunityUiState.Write &&
+                    currentState.postId == intent.postId &&
+                    currentState.title.isNotEmpty()) {
+                    println(">>> [DEBUG_LOAD] Skip API Call - Data already exists")
+                    println("확인해보기 ${currentState.content}")
                 } else {
                     handleLoadPostForEdit(intent.postId)
                 }
@@ -127,6 +130,7 @@ class CommunityViewModel(
             is CommunityIntent.AddMedias -> handleAddMedias(intent.medias)
             is CommunityIntent.RemoveMedia -> handleRemoveMedia(intent.index)
             is CommunityIntent.MoveMedia -> handleMoveMedia(intent.from, intent.to)
+            is CommunityIntent.MoveMediatoLine -> handleMoveMediaToLine(intent.mediaId, intent.targetLineIndex)
             is CommunityIntent.LoadNextPage -> {
                 val currentState = uiState.value as? CommunityUiState.Community
                 if (currentState != null) {
@@ -246,41 +250,57 @@ class CommunityViewModel(
     }
 
     private fun handleLoadPostForEdit(postId: Int) {
-        val currentState = _uiState.value
-        if (currentState is CommunityUiState.Write && currentState.title.isNotEmpty()) {
-            return
+        _uiState.update {
+            if (it is CommunityUiState.Write) it.copy(postId = postId, isLoading = true)
+            else CommunityUiState.Write(postId = postId, isLoading = true)
         }
-
-        _uiState.update { CommunityUiState.Write(postId = postId, isLoading = true) }
 
         viewModelScope.launch {
             getReadPostUseCase(postId).onSuccess { post ->
-                val combinedContent = post.blocks.filter { it.type == "TEXT" }.joinToString("\n") { it.content ?: "" }
-                val mediaItems = post.blocks.filter { it.type != "TEXT" }.mapIndexed { index, block ->
-                    CommunityUiState.MediaItem(
-                        id = block.fileName ?: "media_$index",
-                        uriString = block.fileUrl ?: "",
-                        isVideo = block.type == "VIDEO",
-                        order = block.sequence
-                    )
+                val contentBuilder = StringBuilder()
+                val mediaItems = mutableListOf<CommunityUiState.MediaItem>()
+                val sortedBlocks = post.blocks.sortedBy { it.sequence }
+
+                sortedBlocks.forEachIndexed { index, block ->
+                    when (block.type) {
+                        "TEXT" -> {
+                            contentBuilder.append(block.content ?: "")
+                        }
+                        "IMAGE", "VIDEO" -> {
+                            val currentLine = contentBuilder.count { it == '\n' }
+                            mediaItems.add(
+                                CommunityUiState.MediaItem(
+                                    id = block.fileName ?: "media_${mediaItems.size}",
+                                    uriString = block.fileUrl ?: "",
+                                    isVideo = block.type == "VIDEO",
+                                    order = currentLine
+                                )
+                            )
+                        }
+                    }
+                    if (index < sortedBlocks.lastIndex) {
+                        contentBuilder.append("\n")
+                    }
                 }
 
+                val lastBlock = sortedBlocks.lastOrNull()
+                if (lastBlock != null && (lastBlock.type == "IMAGE" || lastBlock.type == "VIDEO")) {
+                    contentBuilder.append("\n")
+                }
                 _uiState.update {
                     CommunityUiState.Write(
                         postId = postId,
                         title = post.postTitle,
-                        content = combinedContent,
+                        content = contentBuilder.toString(),
                         selectedMedias = mediaItems,
                         isLoading = false
                     )
                 }
-            }.onFailure {
-                _uiState.update { (it as? CommunityUiState.Write)?.copy(isLoading = false) ?: it }
-                _event.emit(CommunityEvent.ShowToast("데이터를 불러오지 못했습니다."))
+            }.onFailure { error ->
+                println(">>> [DEBUG_LOAD] FAILED: $error")
             }
         }
     }
-
     private fun loadReadPost(postId: Int, isRefresh: Boolean = false) {
 
         val currentState = _uiState.value
@@ -347,16 +367,32 @@ class CommunityViewModel(
             val processedNewMedias = (validNewImages + validNewVideos)
 
             if (processedNewMedias.isEmpty()) return@updateWriteState state
-            val lastLineIndex = state.content.split("\n").size - 1
-            val finalNewMedias = processedNewMedias.map {
-                it.copy(order = lastLineIndex.coerceAtLeast(0))
+
+            var currentContent = state.content
+            val lines = if (currentContent.isEmpty()) listOf("") else currentContent.split("\n")
+
+            val startContent = if (currentContent.isNotEmpty() && !currentContent.endsWith("\n")) {
+                currentContent + "\n"
+            } else {
+                currentContent
             }
 
-            val updatedContent = if (state.content.isEmpty()) "\n" else state.content + "\n"
+            val updatedLines = startContent.split("\n").toMutableList()
+            if (updatedLines.last().isEmpty()) updatedLines.removeAt(updatedLines.size - 1)
+
+            val newMediaItems = mutableListOf<CommunityUiState.MediaItem>()
+            var tempContent = startContent
+
+            processedNewMedias.forEachIndexed { index, media ->
+                val targetOrder = tempContent.count { it == '\n' }
+                newMediaItems.add(media.copy(order = targetOrder))
+
+                tempContent += "\n"
+            }
 
             state.copy(
-                content = updatedContent,
-                selectedMedias = currentMedias + finalNewMedias
+                content = tempContent.removeSuffix("\n"),
+                selectedMedias = state.selectedMedias + newMediaItems
             )
         }
     }
@@ -372,12 +408,59 @@ class CommunityViewModel(
 
     private fun handleMoveMedia(from: Int, to: Int) {
         updateWriteState { state ->
-            val newList = state.selectedMedias.toMutableList().apply {
-                if (from in indices && to in indices) {
-                    add(to, removeAt(from))
-                }
+            val medias = state.selectedMedias.toMutableList()
+            if (from !in medias.indices || to !in medias.indices) return@updateWriteState state
+
+            // 1. 리스트 순서 변경
+            val movedItem = medias.removeAt(from)
+            medias.add(to, movedItem)
+
+            val pureTextLines = state.content.split("\n").filter { it.isNotBlank() }
+
+            val updatedMedias = medias.mapIndexed { index, item ->
+                item.copy(order = index)
             }
-            state.copy(selectedMedias = newList)
+
+            val finalLines = mutableListOf<String>()
+
+            repeat(updatedMedias.size) { finalLines.add("") }
+
+            finalLines.addAll(pureTextLines)
+
+            if (finalLines.all { it.isEmpty() } || updatedMedias.isNotEmpty() && pureTextLines.isEmpty()) {
+                if (finalLines.lastOrNull() != "") finalLines.add("")
+            }
+
+            state.copy(
+                content = finalLines.joinToString("\n"),
+                selectedMedias = updatedMedias
+            )
+        }
+    }
+
+    private fun handleMoveMediaToLine(mediaId: String, targetLine: Int) {
+        updateWriteState { state ->
+            val medias = state.selectedMedias.toMutableList()
+            val mediaIndex = medias.indexOfFirst { it.id == mediaId }
+            if (mediaIndex == -1) return@updateWriteState state
+
+            val movedMedia = medias[mediaIndex]
+
+            val lines = state.content.split("\n").toMutableList()
+
+            if (movedMedia.order in lines.indices) {
+                lines.removeAt(movedMedia.order)
+            }
+
+            val safeTarget = targetLine.coerceIn(0, lines.size)
+            lines.add(safeTarget, "")
+
+            medias[mediaIndex] = movedMedia.copy(order = safeTarget)
+
+            state.copy(
+                content = lines.joinToString("\n"),
+                selectedMedias = medias
+            )
         }
     }
 
@@ -389,65 +472,69 @@ class CommunityViewModel(
             try {
                 _uiState.update { if (it is CommunityUiState.Write) it.copy(isLoading = true) else it }
 
-
                 val fileInputs = currentState.selectedMedias
                     .filter { if (isEditMode) !it.uriString.startsWith("http") else true }
                     .map { MediaFile(uriString = it.uriString, isVideo = it.isVideo) }
 
-                val postBlocks = mutableListOf<PostBlock>()
+                val finalPostBlocks = mutableListOf<PostBlock>()
                 val lines = content.split("\n")
 
-                val maxIndex = maxOf(
-                    lines.lastIndex,
-                    currentState.selectedMedias.maxOfOrNull { it.order } ?: 0
-                )
-                for (i in 0..maxIndex) {
-                    currentState.selectedMedias.filter { it.order == i }.forEach { media ->
-                        val block = if (media.isVideo) {
-                            PostBlock.Video(media.uriString)
-                        } else {
-                            PostBlock.Image(media.uriString)
+                println(">>> [DEBUG_SAVE] START - Total Lines: ${lines.size}")
+
+                for (i in lines.indices) {
+                    val lineText = lines[i].trim()
+                    val lineMedias = currentState.selectedMedias.filter { it.order == i }
+
+                    if (lineMedias.isNotEmpty()) {
+                        lineMedias.forEach { media ->
+                            val block = if (media.isVideo) {
+                                PostBlock.Video(videoUrl = media.uriString)
+                            } else {
+                                PostBlock.Image(imageUrl = media.uriString)
+                            }
+                            finalPostBlocks.add(block)
+                            println(">>> [DEBUG_SAVE] Line $i: Adding MEDIA")
                         }
-                        postBlocks.add(block)
                     }
 
-                    if (i <= lines.lastIndex) {
-                        val lineText = lines[i]
-                        if (lineText.isNotBlank()) {
-                            postBlocks.add(PostBlock.Text(text = lineText))
-                        }
+                    if (lineText.isNotEmpty()) {
+                        finalPostBlocks.add(PostBlock.Text(text = lineText))
+                        println(">>> [DEBUG_SAVE] Line $i: Adding TEXT - '$lineText'")
                     }
                 }
+
+                if (finalPostBlocks.isEmpty()) {
+                    _uiState.update { (it as CommunityUiState.Write).copy(isLoading = false) }
+                    _event.emit(CommunityEvent.ShowToast("내용을 입력해주세요."))
+                    return@launch
+                }
+
                 val result = if (isEditMode) {
                     patchCommunityPostUseCase(
                         postId = currentState.postId!!,
                         newFiles = fileInputs,
                         type = currentState.selectedTab.displayName,
                         title = title,
-                        blocks = postBlocks
+                        blocks = finalPostBlocks
                     )
                 } else {
                     postCommunityPostUseCase(
                         files = fileInputs,
                         type = currentState.selectedTab.displayName,
                         title = title,
-                        blocks = postBlocks
+                        blocks = finalPostBlocks
                     )
                 }
+
                 result.onSuccess {
                     _uiState.value = CommunityUiState.Loading
-                    isFetching = false
                     _event.emit(CommunityEvent.WriteSuccess)
-                    loadCommunityData(isNextPage = false)
                 }.onFailure { e ->
-                    println("DEBUG_LOG: 저장 실패 원인: ${e.message}")
                     _uiState.update { if (it is CommunityUiState.Write) it.copy(isLoading = false) else it }
-                    _event.emit(CommunityEvent.ShowToast("저장에 실패했습니다: ${e.message}"))
+                    _event.emit(CommunityEvent.ShowToast(e.message ?: "저장에 실패했습니다."))
                 }
             } catch (e: Exception) {
-                println("DEBUG_LOG: 예외 발생: ${e.stackTraceToString()}")
                 _uiState.update { if (it is CommunityUiState.Write) it.copy(isLoading = false) else it }
-                _event.emit(CommunityEvent.ShowToast("오류가 발생했습니다."))
             }
         }
     }

--- a/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/CommunityViewModel.kt
+++ b/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/CommunityViewModel.kt
@@ -72,7 +72,9 @@ class CommunityViewModel(
     fun onIntent(intent: CommunityIntent){
         when(intent){
             is CommunityIntent.Loading -> {
-                _uiState.value = CommunityUiState.Community(isLoading = true)
+                if (_uiState.value is CommunityUiState.Write) return
+
+                _uiState.value = CommunityUiState.Loading
                 loadCommunityData(tab = CommunityUiState.CommunityTab.ALL)
             }
 
@@ -198,10 +200,14 @@ class CommunityViewModel(
         communityLoadJob?.cancel()
         communityLoadJob = viewModelScope.launch {
             getCommunityPostsUseCase(currentTab.displayName, currentPage, 10).onSuccess { response ->
+                val currentStateBeforeUpdate = _uiState.value
+
+                if (currentStateBeforeUpdate is CommunityUiState.Write) {
+                    isFetching = false
+                    return@launch
+                }
+
                 _uiState.update { state ->
-                    if (state !is CommunityUiState.Community && !isNextPage && state !is CommunityUiState.Loading) {
-                        return@update state
-                    }
 
                     val currentState = when (state) {
                         is CommunityUiState.Community -> state
@@ -228,11 +234,8 @@ class CommunityViewModel(
             }.onFailure {
                 isFetching = false
                 _uiState.update { state ->
-                    val currentState = state as? CommunityUiState.Community ?: CommunityUiState.Community()
-                    currentState.copy(
-                        isLoading = false,
-                        posts = if (currentPage == 0) emptyList() else currentState.posts
-                    )
+                    if (state !is CommunityUiState.Community && state !is CommunityUiState.Loading) state
+                    else (state as? CommunityUiState.Community ?: CommunityUiState.Community()).copy(isLoading = false)
                 }
             }
         }
@@ -389,14 +392,18 @@ class CommunityViewModel(
                 val postBlocks = mutableListOf<PostBlock>()
                 val lines = content.split("\n")
                 lines.forEachIndexed { index, lineText ->
-                    if (lineText.isNotBlank()) postBlocks.add(PostBlock.Text(text = lineText))
-                    currentState.selectedMedias
-                        .filter { it.order == index }
-                        .forEach { media ->
-                            val block = if (media.isVideo) PostBlock.Video(media.uriString)
-                            else PostBlock.Image(media.uriString)
-                            postBlocks.add(block)
+                    if (lineText.isNotBlank()) {
+                        postBlocks.add(PostBlock.Text(text = lineText))
+                    }
+
+                    currentState.selectedMedias.filter { it.order == index }.forEach { media ->
+                        val block = if (media.isVideo) {
+                            PostBlock.Video(media.uriString)
+                        } else {
+                            PostBlock.Image(media.uriString)
                         }
+                        postBlocks.add(block)
+                    }
                 }
 
                 val result = if (isEditMode) {

--- a/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/CommunityViewModel.kt
+++ b/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/CommunityViewModel.kt
@@ -5,6 +5,7 @@ import every.lol.com.core.domain.usecase.DeletePostUseCase
 import every.lol.com.core.domain.usecase.GetCommunityPopularPostsUseCase
 import every.lol.com.core.domain.usecase.GetCommunityPostsUseCase
 import every.lol.com.core.domain.usecase.GetReadPostUseCase
+import every.lol.com.core.domain.usecase.PatchCommunityPostUseCase
 import every.lol.com.core.domain.usecase.PostCommunityCommentUseCase
 import every.lol.com.core.domain.usecase.PostCommunityPostLikeUseCase
 import every.lol.com.core.domain.usecase.PostCommunityPostUseCase
@@ -40,6 +41,7 @@ class CommunityViewModel(
     private val getCommunityPopularPostsUseCase: GetCommunityPopularPostsUseCase,
     private val getReadPostUseCase: GetReadPostUseCase,
     private val postCommunityPostUseCase: PostCommunityPostUseCase,
+    private val patchCommunityPostUseCase: PatchCommunityPostUseCase,
     private val deletePostUseCase: DeletePostUseCase,
     private val reportPostUseCase: ReportPostUseCase,
     private val postCommunityCommentUseCase: PostCommunityCommentUseCase,
@@ -56,6 +58,8 @@ class CommunityViewModel(
 
     private val uploadScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
 
+    private var communityLoadJob: Job? = null
+
     override fun onCleared() {
         super.onCleared()
         uploadScope.cancel()
@@ -69,7 +73,10 @@ class CommunityViewModel(
         when(intent){
             CommunityIntent.Loading -> loadCommunityData(tab = CommunityUiState.CommunityTab.ALL)
             is CommunityIntent.ClickTab -> handleTabClick(intent.tab)
-            is CommunityIntent.ClickWriteTab -> handleWriteTabClick(intent.tab)
+            is CommunityIntent.ClickWriteTab -> {
+                communityLoadJob?.cancel()
+                handleWriteTabClick(intent.tab)
+            }
             is CommunityIntent.DetailPost -> loadReadPost(intent.postId, intent.isRefresh)
             is CommunityIntent.ChangeTitle -> {
                 val currentState = uiState.value
@@ -87,7 +94,25 @@ class CommunityViewModel(
                 }
             }
             is CommunityIntent.WritePost -> {
-                handleWritePost(intent.title, intent.content)
+                handleSavePost(intent.title, intent.content)
+            }
+            is CommunityIntent.EditPost -> {
+                communityLoadJob?.cancel()
+                _uiState.value = CommunityUiState.Write(
+                    postId = intent.postId,
+                    title = intent.title,
+                    content = intent.content,
+                    selectedMedias = intent.medias,
+                    isLoading = false
+                )
+            }
+            is CommunityIntent.LoadPostForEdit -> {
+                val currentState = _uiState.value
+                if (currentState is CommunityUiState.Write && currentState.title.isNotEmpty()) {
+                    _uiState.update { currentState.copy(isLoading = false) }
+                } else {
+                    handleLoadPostForEdit(intent.postId)
+                }
             }
             is CommunityIntent.AddMedias -> handleAddMedias(intent.medias)
             is CommunityIntent.RemoveMedia -> handleRemoveMedia(intent.index)
@@ -166,10 +191,14 @@ class CommunityViewModel(
             currentPage = 0
             isLastPage = false
         }
-
-        viewModelScope.launch {
+        communityLoadJob?.cancel()
+        communityLoadJob = viewModelScope.launch {
             getCommunityPostsUseCase(currentTab.displayName, currentPage, 10).onSuccess { response ->
                 _uiState.update { state ->
+                    if (state !is CommunityUiState.Community && !isNextPage && state !is CommunityUiState.Loading) {
+                        return@update state
+                    }
+
                     val currentState = state as? CommunityUiState.Community ?: CommunityUiState.Community()
 
                     val updatedPosts = if (isNextPage) {
@@ -201,6 +230,42 @@ class CommunityViewModel(
         }
     }
 
+    private fun handleLoadPostForEdit(postId: Int) {
+        val currentState = _uiState.value
+        if (currentState is CommunityUiState.Write && currentState.title.isNotEmpty()) {
+            return
+        }
+
+        _uiState.update { CommunityUiState.Write(postId = postId, isLoading = true) }
+
+        viewModelScope.launch {
+            getReadPostUseCase(postId).onSuccess { post ->
+                val combinedContent = post.blocks.filter { it.type == "TEXT" }.joinToString("\n") { it.content ?: "" }
+                val mediaItems = post.blocks.filter { it.type != "TEXT" }.mapIndexed { index, block ->
+                    CommunityUiState.MediaItem(
+                        id = block.fileName ?: "media_$index",
+                        uriString = block.fileUrl ?: "",
+                        isVideo = block.type == "VIDEO",
+                        order = block.sequence
+                    )
+                }
+
+                _uiState.update {
+                    CommunityUiState.Write(
+                        postId = postId,
+                        title = post.postTitle,
+                        content = combinedContent,
+                        selectedMedias = mediaItems,
+                        isLoading = false
+                    )
+                }
+            }.onFailure {
+                _uiState.update { (it as? CommunityUiState.Write)?.copy(isLoading = false) ?: it }
+                _event.emit(CommunityEvent.ShowToast("데이터를 불러오지 못했습니다."))
+            }
+        }
+    }
+
     private fun loadReadPost(postId: Int, isRefresh: Boolean = false) {
 
         val currentState = _uiState.value
@@ -223,7 +288,7 @@ class CommunityViewModel(
                     val baseState = if (current is CommunityUiState.Read && current.postId == postId) current else CommunityUiState.Read(postId = postId)
 
                     baseState.copy(
-                        post = post, // 이 post 객체 안에 List<PostBlock>이 들어있음
+                        post = post,
                         isLoading = false,
                         isMine = post.isWriter
                     )
@@ -301,17 +366,17 @@ class CommunityViewModel(
         }
     }
 
-    private fun handleWritePost(title: String, content: String) {
+    private fun handleSavePost(title: String, content: String){
         val currentState = _uiState.value as? CommunityUiState.Write ?: return
+        val isEditMode = currentState.postId != null
 
         uploadScope.launch {
             try {
-                val currentJob = coroutineContext[Job]
                 _uiState.update { if (it is CommunityUiState.Write) it.copy(isLoading = true) else it }
 
-                val fileInputs = currentState.selectedMedias.map { media ->
-                    MediaFile(uriString = media.uriString, isVideo = media.isVideo)
-                }
+                val fileInputs = currentState.selectedMedias
+                    .filter { if (isEditMode) !it.uriString.startsWith("http") else true }
+                    .map { MediaFile(uriString = it.uriString, isVideo = it.isVideo) }
 
                 val postBlocks = mutableListOf<PostBlock>()
                 val lines = content.split("\n")
@@ -326,27 +391,35 @@ class CommunityViewModel(
                         }
                 }
 
-                val result = postCommunityPostUseCase(
-                    files = fileInputs,
-                    type = currentState.selectedTab.displayName,
-                    title = title,
-                    blocks = postBlocks
-                )
+                val result = if (isEditMode) {
+                    patchCommunityPostUseCase(
+                        postId = currentState.postId!!,
+                        newFiles = fileInputs,
+                        type = currentState.selectedTab.displayName,
+                        title = title,
+                        blocks = postBlocks
+                    )
+                } else {
+                    postCommunityPostUseCase(
+                        files = fileInputs,
+                        type = currentState.selectedTab.displayName,
+                        title = title,
+                        blocks = postBlocks
+                    )
+                }
 
                 result.onSuccess {
                     _event.emit(CommunityEvent.WriteSuccess)
-                    onIntent(CommunityIntent.Loading)
                 }.onFailure { e ->
                     _uiState.update { if (it is CommunityUiState.Write) it.copy(isLoading = false) else it }
-                    _event.emit(CommunityEvent.ShowToast("업로드에 실패했습니다: ${e.message}"))
+                    _event.emit(CommunityEvent.ShowToast("저장에 실패했습니다: ${e.message}"))
                 }
             } catch (e: Exception) {
                 _uiState.update { if (it is CommunityUiState.Write) it.copy(isLoading = false) else it }
-                _event.emit(CommunityEvent.ShowToast("업로드에 실패했습니다: ${e.message}"))
+                _event.emit(CommunityEvent.ShowToast("저장에 실패했습니다: ${e.message}"))
             }
         }
     }
-
     private fun handleDeletePost(postId: Int) {
         viewModelScope.launch {
             deletePostUseCase(postId).onSuccess {

--- a/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/CommunityViewModel.kt
+++ b/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/CommunityViewModel.kt
@@ -389,18 +389,20 @@ class CommunityViewModel(
             try {
                 _uiState.update { if (it is CommunityUiState.Write) it.copy(isLoading = true) else it }
 
+
                 val fileInputs = currentState.selectedMedias
                     .filter { if (isEditMode) !it.uriString.startsWith("http") else true }
                     .map { MediaFile(uriString = it.uriString, isVideo = it.isVideo) }
 
                 val postBlocks = mutableListOf<PostBlock>()
                 val lines = content.split("\n")
-                lines.forEachIndexed { index, lineText ->
-                    if (lineText.isNotBlank()) {
-                        postBlocks.add(PostBlock.Text(text = lineText))
-                    }
 
-                    currentState.selectedMedias.filter { it.order == index }.forEach { media ->
+                val maxIndex = maxOf(
+                    lines.lastIndex,
+                    currentState.selectedMedias.maxOfOrNull { it.order } ?: 0
+                )
+                for (i in 0..maxIndex) {
+                    currentState.selectedMedias.filter { it.order == i }.forEach { media ->
                         val block = if (media.isVideo) {
                             PostBlock.Video(media.uriString)
                         } else {
@@ -408,8 +410,14 @@ class CommunityViewModel(
                         }
                         postBlocks.add(block)
                     }
-                }
 
+                    if (i <= lines.lastIndex) {
+                        val lineText = lines[i]
+                        if (lineText.isNotBlank()) {
+                            postBlocks.add(PostBlock.Text(text = lineText))
+                        }
+                    }
+                }
                 val result = if (isEditMode) {
                     patchCommunityPostUseCase(
                         postId = currentState.postId!!,
@@ -426,7 +434,6 @@ class CommunityViewModel(
                         blocks = postBlocks
                     )
                 }
-
                 result.onSuccess {
                     _uiState.value = CommunityUiState.Loading
                     isFetching = false

--- a/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/ReadCommunityScreen.kt
+++ b/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/ReadCommunityScreen.kt
@@ -353,26 +353,45 @@ fun ReadCommunityScreen(
                     state.post?.let { post ->
                         val sortedBlocks = post.blocks.sortedBy { it.sequence }
 
-                        val combinedContent = sortedBlocks
-                            .filter { it.type == "TEXT" }
-                            .joinToString("\n") { it.content ?: "" }
+                        val mediaItems = mutableListOf<CommunityUiState.MediaItem>()
+                        val contentBuilder = StringBuilder()
 
-                        val mediaItems = sortedBlocks
-                            .filter { it.type == "IMAGE" || it.type == "VIDEO" }
-                            .mapIndexed { index, block ->
-                                CommunityUiState.MediaItem(
-                                    id = block.fileName ?: block.fileUrl ?: "media_$index",
-                                    uriString = block.fileUrl ?: "",
-                                    isVideo = block.type == "VIDEO",
-                                    order = block.sequence
-                                )
+                        sortedBlocks.forEachIndexed { index, block ->
+                            if (index > 0) {
+                                contentBuilder.append("\n")
                             }
 
+                            when (block.type) {
+                                "TEXT" -> {
+                                    contentBuilder.append(block.content ?: "")
+                                }
+                                "IMAGE", "VIDEO" -> {
+                                    val currentLineIndex =
+                                        if (contentBuilder.isEmpty()) {
+                                            0
+                                        } else {
+                                            contentBuilder.toString().split("\n").lastIndex
+                                        }
+
+                                    mediaItems.add(
+                                        CommunityUiState.MediaItem(
+                                            id = block.fileName ?: block.fileUrl ?: "media_${block.sequence}",
+                                            uriString = block.fileUrl ?: "",
+                                            isVideo = block.type == "VIDEO",
+                                            order = currentLineIndex.coerceAtLeast(0)
+                                        )
+                                    )
+                                }
+                            }
+                        }
+                        if (sortedBlocks.lastOrNull()?.type != "TEXT") {
+                            contentBuilder.append("\n")
+                        }
                         onIntent(
                             CommunityIntent.EditPost(
                                 postId = postId,
                                 title = post.postTitle,
-                                content = combinedContent,
+                                content = contentBuilder.toString(),
                                 medias = mediaItems,
                                 tab = CommunityUiState.WriteTab.entries.find {
                                     it.displayName == post.postType
@@ -380,7 +399,6 @@ fun ReadCommunityScreen(
                             )
                         )
                         onEditClick(postId)
-                        println("DEBUG_LOG: 수정하기 클릭됨, postId: $postId")
                     }
                     isPostMenuExpanded = false
                 },

--- a/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/ReadCommunityScreen.kt
+++ b/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/ReadCommunityScreen.kt
@@ -373,7 +373,10 @@ fun ReadCommunityScreen(
                                 postId = postId,
                                 title = post.postTitle,
                                 content = combinedContent,
-                                medias = mediaItems
+                                medias = mediaItems,
+                                tab = CommunityUiState.WriteTab.entries.find {
+                                    it.displayName == post.postType
+                                } ?: CommunityUiState.WriteTab.TALK
                             )
                         )
                         onEditClick(postId)

--- a/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/ReadCommunityScreen.kt
+++ b/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/ReadCommunityScreen.kt
@@ -85,6 +85,7 @@ fun ReadRoute(
     innerPadding : PaddingValues,
     viewModel: CommunityViewModel = koinViewModel(CommunityViewModel::class),
     onBackClick: () -> Unit,
+    onEditClick: (Int) -> Unit
 ){
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
@@ -104,6 +105,7 @@ fun ReadRoute(
             postId = postId,
             state = currentState,
             onBackClick = onBackClick,
+            onEditClick = onEditClick,
             onIntent = viewModel::onIntent,
             isLiked = currentState.isLiked,
             likeCount = currentState.likeCount
@@ -132,11 +134,11 @@ fun ReadCommunityScreen(
     postId: Int,
     state: CommunityUiState.Read,
     onBackClick: () -> Unit,
+    onEditClick: (Int) -> Unit,
     onIntent: (CommunityIntent) -> Unit,
     isLiked: Boolean = false,
     likeCount: Int = 0
 ) {
-
     var showReportModal by remember { mutableStateOf(false) }
     var reportTargetType by remember { mutableStateOf("") }
     var reportTargetId by remember { mutableStateOf(0) }
@@ -347,6 +349,38 @@ fun ReadCommunityScreen(
                 isMine = state.isMine,
                 onDismiss = { isPostMenuExpanded = false },
                 onDelete = { onIntent(CommunityIntent.DeletePost(postId)) },
+                onEdit = {
+                    state.post?.let { post ->
+                        val sortedBlocks = post.blocks.sortedBy { it.sequence }
+
+                        val combinedContent = sortedBlocks
+                            .filter { it.type == "TEXT" }
+                            .joinToString("\n") { it.content ?: "" }
+
+                        val mediaItems = sortedBlocks
+                            .filter { it.type == "IMAGE" || it.type == "VIDEO" }
+                            .mapIndexed { index, block ->
+                                CommunityUiState.MediaItem(
+                                    id = block.fileName ?: block.fileUrl ?: "media_$index",
+                                    uriString = block.fileUrl ?: "",
+                                    isVideo = block.type == "VIDEO",
+                                    order = block.sequence
+                                )
+                            }
+
+                        onIntent(
+                            CommunityIntent.EditPost(
+                                postId = postId,
+                                title = post.postTitle,
+                                content = combinedContent,
+                                medias = mediaItems
+                            )
+                        )
+                        onEditClick(postId)
+                        println("DEBUG_LOG: 수정하기 클릭됨, postId: $postId")
+                    }
+                    isPostMenuExpanded = false
+                },
                 onReport = {
                     reportTargetType = "게시글"
                     reportTargetId = postId
@@ -392,6 +426,7 @@ fun ReadCommunityScreen(
 fun PostMenu(
     isMine: Boolean,
     onDismiss: () -> Unit,
+    onEdit: () -> Unit,
     onDelete: () -> Unit,
     onReport: () -> Unit
 ) {
@@ -416,7 +451,23 @@ fun PostMenu(
                     DropdownMenuItem(
                         modifier = Modifier
                             .width(80.dp)
-                            .height(24.dp),
+                            .height(36.dp),
+                        text = {
+                            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                                Text(
+                                    "수정하기",
+                                    style = EveryLoLTheme.typography.subtitle03,
+                                    color = EveryLoLTheme.color.community600,
+                                    textAlign = TextAlign.Center
+                                )
+                            }
+                        },
+                        onClick = { onEdit(); onDismiss() }
+                    )
+                    DropdownMenuItem(
+                        modifier = Modifier
+                            .width(80.dp)
+                            .height(36.dp),
                         text = {
                             Box(
                                 modifier = Modifier.fillMaxSize(),

--- a/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/WirteCommunityScreen.kt
+++ b/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/WirteCommunityScreen.kt
@@ -62,26 +62,18 @@ fun WriteRoute(
     onBackClick: () -> Unit
 ){
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    val currentState = uiState
     val focusManager = LocalFocusManager.current
     val snackbarHostState = remember { SnackbarHostState() }
 
-    // 데이터 증발 방지 로직
     LaunchedEffect(postId) {
-        val currentState = viewModel.uiState.value // collect 중인 uiState 말고 실제 value 확인
-
+        val currentState = viewModel.uiState.value
         if (postId != null) {
-            // 수정 모드일 때:
-            // 1. 현재 상태가 Write가 아니거나
-            // 2. Write 상태지만 postId가 다르거나
-            // 3. 데이터(title)가 비어있는 경우에만 서버에서 불러옴
             if (currentState !is CommunityUiState.Write ||
                 currentState.postId != postId ||
                 currentState.title.isEmpty()) {
                 viewModel.onIntent(CommunityIntent.LoadPostForEdit(postId))
             }
         } else {
-            // 새 글 작성 모드일 때:
             if (currentState !is CommunityUiState.Write) {
                 viewModel.onIntent(CommunityIntent.ClickWriteTab(CommunityUiState.WriteTab.TALK))
             }

--- a/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/WirteCommunityScreen.kt
+++ b/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/WirteCommunityScreen.kt
@@ -66,15 +66,17 @@ fun WriteRoute(
     val snackbarHostState = remember { SnackbarHostState() }
 
     LaunchedEffect(postId) {
+        println(">>> [DEBUG_COMMUNITY] LaunchedEffect Start (postId: $postId)")
+
         val currentState = viewModel.uiState.value
+        println(">>> [DEBUG_COMMUNITY] Current State Type: ${currentState::class.simpleName}")
+
         if (postId != null) {
-            if (currentState !is CommunityUiState.Write ||
-                currentState.postId != postId ||
-                currentState.title.isEmpty()) {
-                viewModel.onIntent(CommunityIntent.LoadPostForEdit(postId))
-            }
+            println(">>> [DEBUG_COMMUNITY] Calling LoadPostForEdit($postId)")
+            viewModel.onIntent(CommunityIntent.LoadPostForEdit(postId))
         } else {
             if (currentState !is CommunityUiState.Write) {
+                println(">>> [DEBUG_COMMUNITY] Setting default WriteTab")
                 viewModel.onIntent(CommunityIntent.ClickWriteTab(CommunityUiState.WriteTab.TALK))
             }
         }
@@ -128,7 +130,9 @@ fun WriteCommunityScreen(
         scope.launch(Dispatchers.Default) {
             val currentImages = state.selectedMedias.filter { !it.isVideo }
             val currentVideos = state.selectedMedias.filter { it.isVideo }
-            val currentOrder = (state.content.split("\n").size - 1).coerceAtLeast(0)
+
+            val lines = state.content.split("\n")
+            val lastLineIndex = lines.lastIndex
 
             val newMediaList = mutableListOf<CommunityUiState.MediaItem>()
             var imageCountInBatch = 0
@@ -136,7 +140,6 @@ fun WriteCommunityScreen(
 
             results.forEach { result ->
                 val uriString = result.toString()
-
                 val isVideo = isVideoUri(result, context)
 
                 if (isVideo && (currentVideos.size + videoCountInBatch < 2)) {
@@ -148,19 +151,19 @@ fun WriteCommunityScreen(
                             thumbnail = metadata.thumbnail,
                             isVideo = true,
                             durationMs = metadata.durationMs,
-                            order = currentOrder
+                            order = lastLineIndex
                         )
                     )
                     videoCountInBatch++
                 } else if (!isVideo && (currentImages.size + imageCountInBatch < 10)) {
                     newMediaList.add(
                         CommunityUiState.MediaItem(
-                            id = "img_${Clock.System.now().toEpochMilliseconds()}",
+                            id = "img_${Clock.System.now().toEpochMilliseconds()}_$imageCountInBatch", // ID 중복 방지
                             uriString = uriString,
                             thumbnail = null,
                             isVideo = false,
                             durationMs = 0L,
-                            order = currentOrder
+                            order = if (state.content.isEmpty()) 0 else lines.size - 1
                         )
                     )
                     imageCountInBatch++
@@ -259,11 +262,12 @@ fun WriteCommunityScreen(
                     title = if(isEditMode) "게시글을 수정할까요?" else "게시글이 완성되었어요",
                     context = if (isEditMode) "수정된 내용은 즉시 반영됩니다." else "게시글을 올리겠습니까?",
                     onConfirm = {
-                            onIntent(CommunityIntent.WritePost(
-                                state.title,
-                                state.content,
-                                state.selectedMedias
-                            ))
+                        onIntent(CommunityIntent.WritePost(
+                            state.title,
+                            state.content,
+                            state.selectedMedias
+                        ))
+                        showWritePostModal = false
                     },
                     onDismiss = { showWritePostModal = false }
                 )

--- a/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/WirteCommunityScreen.kt
+++ b/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/WirteCommunityScreen.kt
@@ -56,6 +56,7 @@ import kotlin.time.Clock
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun WriteRoute(
+    postId: Int?= null,
     innerPadding : PaddingValues,
     viewModel: CommunityViewModel = koinViewModel(CommunityViewModel::class),
     onBackClick: () -> Unit
@@ -65,11 +66,28 @@ fun WriteRoute(
     val focusManager = LocalFocusManager.current
     val snackbarHostState = remember { SnackbarHostState() }
 
-    LaunchedEffect(Unit) {
-        if (uiState !is CommunityUiState.Write) {
-            viewModel.onIntent(CommunityIntent.ClickWriteTab(CommunityUiState.WriteTab.TALK))
+    // 데이터 증발 방지 로직
+    LaunchedEffect(postId) {
+        val currentState = viewModel.uiState.value // collect 중인 uiState 말고 실제 value 확인
+
+        if (postId != null) {
+            // 수정 모드일 때:
+            // 1. 현재 상태가 Write가 아니거나
+            // 2. Write 상태지만 postId가 다르거나
+            // 3. 데이터(title)가 비어있는 경우에만 서버에서 불러옴
+            if (currentState !is CommunityUiState.Write ||
+                currentState.postId != postId ||
+                currentState.title.isEmpty()) {
+                viewModel.onIntent(CommunityIntent.LoadPostForEdit(postId))
+            }
+        } else {
+            // 새 글 작성 모드일 때:
+            if (currentState !is CommunityUiState.Write) {
+                viewModel.onIntent(CommunityIntent.ClickWriteTab(CommunityUiState.WriteTab.TALK))
+            }
         }
     }
+
 
     LaunchedEffect(viewModel.event) {
         viewModel.event.collect { event ->
@@ -87,9 +105,9 @@ fun WriteRoute(
     }
 
     Box(modifier = Modifier.fillMaxSize()) {
-        if (currentState is CommunityUiState.Write) {
+        (uiState as? CommunityUiState.Write)?.let { state ->
             WriteCommunityScreen(
-                state = currentState,
+                state = state,
                 onBackClick = onBackClick,
                 onIntent = viewModel::onIntent,
                 snackbarHostState = snackbarHostState
@@ -106,6 +124,7 @@ fun WriteCommunityScreen(
     snackbarHostState: SnackbarHostState
 ) {
 
+    val isEditMode = state.postId != null
     val scope = rememberCoroutineScope()
     val isFormValid = state.title.isNotBlank() && state.content.isNotBlank()
     var showWritePostModal by remember { mutableStateOf(false) }
@@ -170,7 +189,7 @@ fun WriteCommunityScreen(
             contentWindowInsets = WindowInsets(0, 0, 0, 0),
             snackbarHost = { EverylolToastHost(snackbarHostState) },
             topBar = {
-                EverylolTopAppBar(onBackClick = onBackClick, title = "글 작성하기")
+                EverylolTopAppBar(onBackClick = onBackClick, title = if(isEditMode) "글 수정하기" else "글 작성하기")
             },
             bottomBar = {
                 if (isKeyboardVisible) {
@@ -239,23 +258,20 @@ fun WriteCommunityScreen(
                     .align(Alignment.BottomCenter)
                     .padding(horizontal = 24.dp, vertical = 24.dp)
                     .fillMaxWidth(),
-                text = "게시글 올리기",
+                text = if(isEditMode) "수정 완료" else "게시글 올리기",
                 enabled = isFormValid,
                 onClick = { showWritePostModal = true }
             )
             if (showWritePostModal) {
                 EverylolModal(
-                    title = "게시글이 완성되었어요",
-                    context = "게시글을 올리겠습니까?",
+                    title = if(isEditMode) "게시글을 수정할까요?" else "게시글이 완성되었어요",
+                    context = if (isEditMode) "수정된 내용은 즉시 반영됩니다." else "게시글을 올리겠습니까?",
                     onConfirm = {
-                        onIntent(
-                            CommunityIntent.WritePost(
+                            onIntent(CommunityIntent.WritePost(
                                 state.title,
                                 state.content,
                                 state.selectedMedias
-                            )
-                        )
-                        // showWritePostModal = false
+                            ))
                     },
                     onDismiss = { showWritePostModal = false }
                 )

--- a/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/component/CommunityContentWrite.kt
+++ b/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/component/CommunityContentWrite.kt
@@ -67,8 +67,8 @@ fun CommunityContentWriteBlock(
     val allItems = remember(textLines, state.selectedMedias) {
         val list = mutableListOf<String>()
         textLines.forEachIndexed { index, _ ->
-            list.add("text_block_$index")
             state.selectedMedias.filter { it.order == index }.forEach { list.add(it.id) }
+            list.add("text_block_$index")
         }
         val assignedIds = list.toSet()
         state.selectedMedias.filter { it.id !in assignedIds }.forEach { list.add(it.id) }
@@ -94,7 +94,13 @@ fun CommunityContentWriteBlock(
         list = allItems,
         onSettle = { from, to ->
             val fromId = allItems.getOrNull(from) ?: ""
-            if (state.selectedMedias.any { it.id == fromId }) {
+            val toId = allItems.getOrNull(to) ?: ""
+            val fromMediaIndex = state.selectedMedias.indexOfFirst { it.id == fromId }
+            val toMediaIndex = state.selectedMedias.indexOfFirst { it.id == toId }
+
+            if (fromMediaIndex != -1 && toMediaIndex != -1) {
+                onIntent(CommunityIntent.MoveMedia(fromMediaIndex, toMediaIndex))
+            } else if (fromMediaIndex != -1) {
                 val nearestTextIndex = allItems.subList(0, (to + 1).coerceAtMost(allItems.size))
                     .filter { it.startsWith("text_block_") }
                     .lastOrNull()

--- a/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/model/CommunityUiModel.kt
+++ b/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/model/CommunityUiModel.kt
@@ -41,6 +41,7 @@ sealed interface CommunityUiState {
     ) : CommunityUiState
 
     data class Write(
+        val postId: Int? = null,
         val isLoading: Boolean = false,
         val selectedTab: WriteTab = WriteTab.TALK,
         val title: String = "",
@@ -76,6 +77,16 @@ sealed interface CommunityIntent{
         val content: String,
         val medias: List<CommunityUiState.MediaItem>
     ) : CommunityIntent
+
+    data class LoadPostForEdit(val postId: Int) : CommunityIntent
+
+    data class EditPost(
+        val postId: Int,
+        val title: String,
+        val content: String,
+        val medias: List<CommunityUiState.MediaItem>
+    ) : CommunityIntent
+
     data object OpenGallery : CommunityIntent
     data class AddMedias(val medias: List<CommunityUiState.MediaItem>) : CommunityIntent
     data class RemoveMedia(val index: Int) : CommunityIntent

--- a/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/model/CommunityUiModel.kt
+++ b/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/model/CommunityUiModel.kt
@@ -92,6 +92,7 @@ sealed interface CommunityIntent{
     data class AddMedias(val medias: List<CommunityUiState.MediaItem>) : CommunityIntent
     data class RemoveMedia(val index: Int) : CommunityIntent
     data class MoveMedia(val from: Int, val to: Int) : CommunityIntent
+    data class MoveMediatoLine(val mediaId: String, val targetLineIndex: Int) : CommunityIntent
     data class UpdateMediaOrder(val mediaId: String, val newOrder: Int) : CommunityIntent
     data class WriteComment(val postId: Int, val content: String) : CommunityIntent
     data class WriteReply(val postId: Int, val parentCommentId: Long, val content: String) : CommunityIntent

--- a/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/model/CommunityUiModel.kt
+++ b/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/model/CommunityUiModel.kt
@@ -84,7 +84,8 @@ sealed interface CommunityIntent{
         val postId: Int,
         val title: String,
         val content: String,
-        val medias: List<CommunityUiState.MediaItem>
+        val medias: List<CommunityUiState.MediaItem>,
+        val tab:CommunityUiState.WriteTab
     ) : CommunityIntent
 
     data object OpenGallery : CommunityIntent

--- a/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/navigation/ReadNavigator.kt
+++ b/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/navigation/ReadNavigator.kt
@@ -16,14 +16,16 @@ fun NavController.navigateRead(postId: Int, navOptions: NavOptions? = null) {
 
 fun NavGraphBuilder.readNavGraph(
     innerPadding: PaddingValues,
-    onBackClick: () -> Unit
+    onBackClick: () -> Unit,
+    onEditClick: (Int) -> Unit
 ) {
     composable<Route.Read> { backStackEntry ->
         val readRoute: Route.Read = backStackEntry.toRoute()
         ReadRoute(
             postId = readRoute.postId,
             innerPadding = innerPadding,
-            onBackClick = onBackClick
+            onBackClick = onBackClick,
+            onEditClick = onEditClick
         )
     }
 }

--- a/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/navigation/WriteNavigator.kt
+++ b/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/navigation/WriteNavigator.kt
@@ -5,20 +5,24 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
+import androidx.navigation.toRoute
 import every.lol.com.core.navigation.Route
 import every.lol.com.feature.community.WriteRoute
 
 
-fun NavController.navigateWrite(navOptions: NavOptions? = null) {
-    navigate(route = Route.Write, navOptions = navOptions)
+fun NavController.navigateWrite(postId: Int?=null, navOptions: NavOptions? = null) {
+    navigate(route = Route.Write(postId = postId), navOptions = navOptions)
 }
 
 fun NavGraphBuilder.writeNavGraph(
     innerPadding: PaddingValues,
     onBackClick: () -> Unit,
 ) {
-    composable<Route.Write> {
+    composable<Route.Write> {backStackEntry ->
+        val writeRoute = backStackEntry.toRoute<Route.Write>()
+
         WriteRoute(
+            postId = writeRoute.postId,
             innerPadding = innerPadding,
             onBackClick = onBackClick,
         )


### PR DESCRIPTION
- closed #86 

## 📝작업 내용
> 게시글 수정 기능 구현 및 데이터 동기화 작업 완료
- 기존 게시글 데이터를 수정 폼에 불러오는 바인딩 로직 구현
- 제목, 본문, 이미지 등 변경된 데이터의 서버 전송 기능 개발
- 수정 완료 후 상세 페이지 리다이렉트 처리
- 권한 없는 사용자의 수정 접근 차단 로직 적용

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
> 게시글 수정 과정에서 간헐적으로 데이터 반영 속도나 갱신 오류가 발생할 가능성이 있어, 비동기 처리 로직과 상태 업데이트 부분 위주로 검토 바람

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 게시물 수정 기능 추가 - 제목, 내용, 미디어를 포함한 기존 게시물 편집 가능
  * 게시물 옵션 메뉴에 "수정하기" 옵션 추가
  * 미디어 재정렬 기능 개선 - 편집 시 미디어 위치 조정 가능
  * 게시물 편집 시 자동 상태 관리

<!-- end of auto-generated comment: release notes by coderabbit.ai -->