### PR TITLE
[Feat/#97] aboutlck 날짜 및 UI 구현

### DIFF
--- a/core/common/src/androidMain/kotlin/every/lol/com/core/common/DatePicker.kt
+++ b/core/common/src/androidMain/kotlin/every/lol/com/core/common/DatePicker.kt
@@ -1,0 +1,13 @@
+package every.lol.com.core.common
+
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import kotlin.text.format
+import java.time.Instant
+
+
+actual fun formatMillisToDate(millis: Long): String {
+    val instant = Instant.ofEpochMilli(millis)
+    val date = instant.atZone(ZoneId.of("UTC")).toLocalDate()
+    return date.format(DateTimeFormatter.ISO_LOCAL_DATE)
+}

--- a/core/common/src/commonMain/kotlin/every/lol/com/core/common/DatePicker.kt
+++ b/core/common/src/commonMain/kotlin/every/lol/com/core/common/DatePicker.kt
@@ -1,0 +1,3 @@
+package every.lol.com.core.common
+
+expect fun formatMillisToDate(millis: Long): String

--- a/core/common/src/iosMain/kotlin/every/lol/com/core/common/DatePicker.kt
+++ b/core/common/src/iosMain/kotlin/every/lol/com/core/common/DatePicker.kt
@@ -1,0 +1,18 @@
+package every.lol.com.core.common
+
+import platform.Foundation.NSDate
+import platform.Foundation.NSDateFormatter
+import platform.Foundation.NSTimeZone
+import platform.Foundation.dateWithTimeIntervalSince1970
+import platform.Foundation.timeZoneWithName
+
+actual fun formatMillisToDate(millis: Long): String {
+    val date = NSDate.dateWithTimeIntervalSince1970(millis / 1000.0)
+
+    val formatter = NSDateFormatter().apply {
+        dateFormat = "yyyy-MM-dd"
+        timeZone = NSTimeZone.timeZoneWithName("UTC")!!
+    }
+
+    return formatter.stringFromDate(date)
+}

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -15,7 +15,7 @@ kotlin {
             implementation(project(":core:datastore"))
             implementation(project(":core:common"))
             api(project(":core:domain"))
-            implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.0")
+            implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.7.1")
             implementation(libs.koin.core)
         }
     }

--- a/core/ui/src/commonMain/composeResources/drawable/ic_double_arrow_right.xml
+++ b/core/ui/src/commonMain/composeResources/drawable/ic_double_arrow_right.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="9dp"
+    android:height="8dp"
+    android:viewportWidth="9"
+    android:viewportHeight="8">
+  <path
+      android:pathData="M7.9923,3.0876L4.9071,0L4.084,0.8248L7.1692,3.9124L4.084,7L4.9094,7.8248L7.9923,4.7372C8.211,4.5185 8.3339,4.2218 8.3339,3.9124C8.3339,3.6031 8.211,3.3064 7.9923,3.0876Z"
+      android:fillColor="#AEAEAE"/>
+  <path
+      android:pathData="M4.3231,3.5L0.8231,0L0,0.8248L3.0852,3.9124L0,7L0.8254,7.8248L4.3254,4.3248C4.4345,4.2151 4.4955,4.0666 4.495,3.9119C4.4946,3.7573 4.4328,3.6091 4.3231,3.5Z"
+      android:fillColor="#AEAEAE"/>
+</vector>

--- a/core/ui/src/commonMain/kotlin/every/lol/com/core/ui/component/LCKRankingSection.kt
+++ b/core/ui/src/commonMain/kotlin/every/lol/com/core/ui/component/LCKRankingSection.kt
@@ -51,7 +51,7 @@ fun LckRankingSection(
     // cardBackground: @Composable BoxScope.(LckStandingTeamModel) -> Unit = {}
 ) {
     if (standings.isEmpty()) {
-        EmptyContent("headset", "경기가 아직 진행되지 않았습니다")
+        EmptyContent("headset", "경기가 아직 진행되지 않았습니다", modifier)
         return
     }
 

--- a/core/ui/src/commonMain/kotlin/every/lol/com/core/ui/component/MatchPredictionSection.kt
+++ b/core/ui/src/commonMain/kotlin/every/lol/com/core/ui/component/MatchPredictionSection.kt
@@ -26,7 +26,7 @@ import everylol.core.ui.generated.resources.ic_double_arrow_right
 import org.jetbrains.compose.resources.painterResource
 
 @Composable
-fun MatchPredicionSection(
+fun MatchPredictionSection(
     data: MatchCardModel,
     title: String,
     onPredictionClick: (() -> Unit)? = null,

--- a/core/ui/src/commonMain/kotlin/every/lol/com/core/ui/component/MatchPredictionSection.kt
+++ b/core/ui/src/commonMain/kotlin/every/lol/com/core/ui/component/MatchPredictionSection.kt
@@ -1,0 +1,177 @@
+package every.lol.com.core.ui.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import every.lol.com.core.designsystem.theme.EveryLoLTheme
+import every.lol.com.core.model.MatchCardModel
+import every.lol.com.core.model.MatchStatus
+import everylol.core.ui.generated.resources.Res
+import everylol.core.ui.generated.resources.ic_double_arrow_right
+import org.jetbrains.compose.resources.painterResource
+
+@Composable
+fun MatchPredicionSection(
+    data: MatchCardModel,
+    title: String,
+    onPredictionClick: (() -> Unit)? = null,
+) {
+
+
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            modifier = Modifier.clickable(
+                enabled = onPredictionClick != null,
+                onClick = { onPredictionClick?.invoke() }
+            )
+        ) {
+            Text(
+                text = title,
+                color = if(title == "승부예측결과")EveryLoLTheme.color.gray800 else EveryLoLTheme.color.grayScale600,
+                style = EveryLoLTheme.typography.subtitle03
+            )
+            if(title == "승부 & MVP 투표") {
+                Icon(
+                    painter = painterResource(Res.drawable.ic_double_arrow_right),
+                    contentDescription = "투표 화면 이동",
+                    tint = EveryLoLTheme.color.grayScale600,
+                    modifier = Modifier.size(width = 8.3.dp, height = 7.8.dp)
+                )
+            }
+        }
+
+        PredictionBarByStatus(
+            status = data.matchStatus,
+            team1Rate = data.team1VoteRate,
+            team2Rate = data.team2VoteRate,
+            team1Name = data.team1Name,
+            team2Name = data.team2Name,
+            predictedWinnerTeamName = data.predictedWinnerTeamName
+        )
+
+        TeamNameRow(
+            team1Name = data.team1Name,
+            team2Name = data.team2Name,
+            predictedWinnerTeamName = data.predictedWinnerTeamName,
+            status = data.matchStatus
+        )
+    }
+}
+
+
+
+
+@Composable
+private fun TeamNameRow(
+    team1Name: String,
+    team2Name: String,
+    predictedWinnerTeamName: String?,
+    status: MatchStatus,
+    modifier: Modifier = Modifier
+) {
+
+    val team1IsWinner = predictedWinnerTeamName == team1Name
+    val team2IsWinner = predictedWinnerTeamName == team2Name
+
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = team1Name,
+            color = if(team1IsWinner)getTeamColor(team1Name) else EveryLoLTheme.color.grayScale800,
+            style = EveryLoLTheme.typography.body03
+        )
+
+        Text(
+            text = team2Name,
+            color = if(team2IsWinner)getTeamColor(team2Name) else EveryLoLTheme.color.grayScale800,
+            style = EveryLoLTheme.typography.body03
+        )
+    }
+}
+
+@Composable
+private fun getBarColor(
+    status: MatchStatus,
+    isWinner: Boolean,
+    teamName: String
+): Color {
+    return when (status) {
+        MatchStatus.SCHEDULED -> getTeamColor(teamName)
+        MatchStatus.LIVE -> EveryLoLTheme.color.gray800
+        MatchStatus.FINISHED -> {
+            if (isWinner) getTeamColor(teamName)
+            else EveryLoLTheme.color.gray800
+        }
+    }
+}
+
+@Composable
+private fun PredictionBarByStatus(
+    status: MatchStatus,
+    team1Rate: Double,
+    team2Rate: Double,
+    team1Name: String,
+    team2Name: String,
+    predictedWinnerTeamName: String?,
+    modifier: Modifier = Modifier
+) {
+    val leftWeight = if (team1Rate <= 0.0 && team2Rate <= 0.0) 1f else (team1Rate.coerceAtLeast(0.1) / 100.0).toFloat()
+    val rightWeight = if (team1Rate <= 0.0 && team2Rate <= 0.0) 1f else (team2Rate.coerceAtLeast(0.1) / 100.0).toFloat()
+
+    val leftColor = getBarColor(
+        status = status,
+        isWinner = predictedWinnerTeamName == team1Name,
+        teamName = team1Name
+    )
+
+    val rightColor = getBarColor(
+        status = status,
+        isWinner = predictedWinnerTeamName == team2Name,
+        teamName = team2Name
+    )
+
+
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .weight(leftWeight)
+                .height(4.dp)
+                .clip(RoundedCornerShape(999.dp))
+                .background(leftColor)
+        )
+
+        Box(
+            modifier = Modifier
+                .weight(rightWeight)
+                .height(4.dp)
+                .clip(RoundedCornerShape(999.dp))
+                .background(rightColor)
+        )
+    }
+}

--- a/feature/aboutlck/build.gradle.kts
+++ b/feature/aboutlck/build.gradle.kts
@@ -9,7 +9,7 @@ setNamespace("feature.aboutlck")
 kotlin {
     sourceSets {
         commonMain.dependencies {
-
+            implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.7.1")
         }
     }
 }

--- a/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/AboutLCKMatchScreen.kt
+++ b/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/AboutLCKMatchScreen.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.unit.dp
 import every.lol.com.core.designsystem.component.EverylolTopAppBar
 import every.lol.com.core.designsystem.theme.EveryLoLTheme
 import every.lol.com.core.model.MatchStatus
-import every.lol.com.core.ui.component.MatchPredicionSection
+import every.lol.com.core.ui.component.MatchPredictionSection
 import every.lol.com.core.ui.ext.everylolDefault
 import every.lol.com.feature.aboutlck.component.AboutLCKMatchCard
 import every.lol.com.feature.aboutlck.model.AboutLCKIntent
@@ -58,7 +58,7 @@ fun AboutLCKMatchScreen(
             }
             if(aboutLCKMatchState!!.matchData.matchStatus == MatchStatus.FINISHED) {
                 item {
-                    MatchPredicionSection(
+                    MatchPredictionSection(
                         data = aboutLCKMatchState.matchData,
                         title = "승부예측결과"
                     )

--- a/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/AboutLCKMatchScreen.kt
+++ b/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/AboutLCKMatchScreen.kt
@@ -1,0 +1,55 @@
+package every.lol.com.feature.aboutlck
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import every.lol.com.core.designsystem.component.EverylolTopAppBar
+import every.lol.com.core.designsystem.theme.EveryLoLTheme
+import every.lol.com.core.ui.ext.everylolDefault
+import every.lol.com.feature.aboutlck.model.AboutLCKIntent
+import every.lol.com.feature.aboutlck.model.AboutLCKUiState
+
+@Composable
+fun AboutLCKMatchScreen(
+    state: AboutLCKUiState,
+    snackbarHostState: SnackbarHostState,
+    onIntent: (AboutLCKIntent) -> Unit
+) {
+
+    val aboutLCKState = state as? AboutLCKUiState.AboutLCK
+
+        Scaffold(
+            modifier = Modifier
+                .fillMaxSize()
+                .everylolDefault(EveryLoLTheme.color.newBg, false),
+            containerColor = Color.Transparent,
+            contentWindowInsets = WindowInsets(0, 0, 0, 0),
+            snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
+            topBar = {
+                EverylolTopAppBar(title = "About LCK")
+            }
+        ) { innerPadding ->
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(top = innerPadding.calculateTopPadding(), bottom = 0.dp)
+                    .padding(horizontal = 16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(20.dp)
+            ) {
+                item {
+
+                }
+            }
+        }
+    }

--- a/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/AboutLCKMatchScreen.kt
+++ b/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/AboutLCKMatchScreen.kt
@@ -15,6 +15,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import every.lol.com.core.designsystem.component.EverylolTopAppBar
 import every.lol.com.core.designsystem.theme.EveryLoLTheme
+import every.lol.com.core.model.MatchStatus
+import every.lol.com.core.ui.component.MatchPredicionSection
 import every.lol.com.core.ui.ext.everylolDefault
 import every.lol.com.feature.aboutlck.component.AboutLCKMatchCard
 import every.lol.com.feature.aboutlck.model.AboutLCKIntent
@@ -27,33 +29,41 @@ fun AboutLCKMatchScreen(
     onBackClick: () -> Unit,
     onIntent: (AboutLCKIntent) -> Unit
 ) {
+    val aboutLCKMatchState = state as? AboutLCKUiState.Match
 
-    val aboutLCKState = state as? AboutLCKUiState.Match
-
-        Scaffold(
+    Scaffold(
+        modifier = Modifier
+            .fillMaxSize()
+            .everylolDefault(EveryLoLTheme.color.newBg, false),
+        containerColor = Color.Transparent,
+        contentWindowInsets = WindowInsets(0, 0, 0, 0),
+        snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
+        topBar = {
+            EverylolTopAppBar(onBackClick = onBackClick, title = "About LCK")
+        }
+    ) { innerPadding ->
+        LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
-                .everylolDefault(EveryLoLTheme.color.newBg, false),
-            containerColor = Color.Transparent,
-            contentWindowInsets = WindowInsets(0, 0, 0, 0),
-            snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
-            topBar = {
-                EverylolTopAppBar(onBackClick = onBackClick, title = "About LCK")
+                .padding(top = innerPadding.calculateTopPadding(), bottom = 0.dp)
+                .padding(horizontal = 16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(20.dp)
+        ) {
+            item {
+                AboutLCKMatchCard(
+                    item = aboutLCKMatchState!!.matchData,
+                    modifier = Modifier.padding(top = 20.dp)
+                )
             }
-        ) { innerPadding ->
-            LazyColumn(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(top = innerPadding.calculateTopPadding(), bottom = 0.dp)
-                    .padding(horizontal = 16.dp),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(20.dp)
-            ) {
+            if(aboutLCKMatchState!!.matchData.matchStatus == MatchStatus.FINISHED) {
                 item {
-                    AboutLCKMatchCard(
-                        item = aboutLCKState!!.matchData
+                    MatchPredicionSection(
+                        data = aboutLCKMatchState.matchData,
+                        title = "승부예측결과"
                     )
                 }
             }
         }
     }
+}

--- a/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/AboutLCKMatchScreen.kt
+++ b/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/AboutLCKMatchScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.unit.dp
 import every.lol.com.core.designsystem.component.EverylolTopAppBar
 import every.lol.com.core.designsystem.theme.EveryLoLTheme
 import every.lol.com.core.ui.ext.everylolDefault
+import every.lol.com.feature.aboutlck.component.AboutLCKMatchCard
 import every.lol.com.feature.aboutlck.model.AboutLCKIntent
 import every.lol.com.feature.aboutlck.model.AboutLCKUiState
 
@@ -23,10 +24,11 @@ import every.lol.com.feature.aboutlck.model.AboutLCKUiState
 fun AboutLCKMatchScreen(
     state: AboutLCKUiState,
     snackbarHostState: SnackbarHostState,
+    onBackClick: () -> Unit,
     onIntent: (AboutLCKIntent) -> Unit
 ) {
 
-    val aboutLCKState = state as? AboutLCKUiState.AboutLCK
+    val aboutLCKState = state as? AboutLCKUiState.Match
 
         Scaffold(
             modifier = Modifier
@@ -36,7 +38,7 @@ fun AboutLCKMatchScreen(
             contentWindowInsets = WindowInsets(0, 0, 0, 0),
             snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
             topBar = {
-                EverylolTopAppBar(title = "About LCK")
+                EverylolTopAppBar(onBackClick = onBackClick, title = "About LCK")
             }
         ) { innerPadding ->
             LazyColumn(
@@ -48,7 +50,9 @@ fun AboutLCKMatchScreen(
                 verticalArrangement = Arrangement.spacedBy(20.dp)
             ) {
                 item {
-
+                    AboutLCKMatchCard(
+                        item = aboutLCKState!!.matchData
+                    )
                 }
             }
         }

--- a/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/AboutLCKPlayerScreen.kt
+++ b/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/AboutLCKPlayerScreen.kt
@@ -23,33 +23,31 @@ import every.lol.com.feature.aboutlck.model.AboutLCKUiState
 fun AboutLCKPlayerScreen(
     state: AboutLCKUiState,
     snackbarHostState: SnackbarHostState,
+    onBackClick: () -> Unit,
     onIntent: (AboutLCKIntent) -> Unit
 ) {
-
-    val aboutLCKState = state as? AboutLCKUiState.AboutLCK
-
-        Scaffold(
+    Scaffold(
+        modifier = Modifier
+            .fillMaxSize()
+            .everylolDefault(EveryLoLTheme.color.newBg, false),
+        containerColor = Color.Transparent,
+        contentWindowInsets = WindowInsets(0, 0, 0, 0),
+        snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
+        topBar = {
+            EverylolTopAppBar(onBackClick = onBackClick ,title = "About LCK")
+        }
+    ) { innerPadding ->
+        LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
-                .everylolDefault(EveryLoLTheme.color.newBg, false),
-            containerColor = Color.Transparent,
-            contentWindowInsets = WindowInsets(0, 0, 0, 0),
-            snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
-            topBar = {
-                EverylolTopAppBar(title = "About LCK")
-            }
-        ) { innerPadding ->
-            LazyColumn(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(top = innerPadding.calculateTopPadding(), bottom = 0.dp)
-                    .padding(horizontal = 16.dp),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(20.dp)
-            ) {
-                item {
+                .padding(top = innerPadding.calculateTopPadding(), bottom = 0.dp)
+                .padding(horizontal = 16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(20.dp)
+        ) {
+            item {
 
-                }
             }
         }
     }
+}

--- a/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/AboutLCKPlayerScreen.kt
+++ b/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/AboutLCKPlayerScreen.kt
@@ -1,0 +1,55 @@
+package every.lol.com.feature.aboutlck
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import every.lol.com.core.designsystem.component.EverylolTopAppBar
+import every.lol.com.core.designsystem.theme.EveryLoLTheme
+import every.lol.com.core.ui.ext.everylolDefault
+import every.lol.com.feature.aboutlck.model.AboutLCKIntent
+import every.lol.com.feature.aboutlck.model.AboutLCKUiState
+
+@Composable
+fun AboutLCKPlayerScreen(
+    state: AboutLCKUiState,
+    snackbarHostState: SnackbarHostState,
+    onIntent: (AboutLCKIntent) -> Unit
+) {
+
+    val aboutLCKState = state as? AboutLCKUiState.AboutLCK
+
+        Scaffold(
+            modifier = Modifier
+                .fillMaxSize()
+                .everylolDefault(EveryLoLTheme.color.newBg, false),
+            containerColor = Color.Transparent,
+            contentWindowInsets = WindowInsets(0, 0, 0, 0),
+            snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
+            topBar = {
+                EverylolTopAppBar(title = "About LCK")
+            }
+        ) { innerPadding ->
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(top = innerPadding.calculateTopPadding(), bottom = 0.dp)
+                    .padding(horizontal = 16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(20.dp)
+            ) {
+                item {
+
+                }
+            }
+        }
+    }

--- a/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/AboutLCKScreen.kt
+++ b/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/AboutLCKScreen.kt
@@ -15,21 +15,27 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import every.lol.com.core.common.formatMillisToDate
 import every.lol.com.core.designsystem.component.EverylolTopAppBar
 import every.lol.com.core.designsystem.theme.EveryLoLTheme
 import every.lol.com.core.ui.component.LckRankingSection
@@ -40,6 +46,7 @@ import every.lol.com.feature.aboutlck.model.AboutLCKIntent
 import every.lol.com.feature.aboutlck.model.AboutLCKUiState
 import moe.tlaster.precompose.koin.koinViewModel
 
+@OptIn(ExperimentalMultiplatform::class)
 @Composable
 fun AboutLCKRoute(
     viewModel: AboutLCKViewModel = koinViewModel(AboutLCKViewModel ::class)
@@ -86,10 +93,38 @@ fun AboutLCKScreen(
     val aboutLCKState = state as? AboutLCKUiState.AboutLCK
     val ranking = aboutLCKState?.ranking?.groups?.firstOrNull()?.teams ?: emptyList()
     val matches = aboutLCKState?.match?.matches ?: emptyList()
-    var showCalender =  remember { mutableStateOf(false) }
+    var showCalender by remember { mutableStateOf(false) }
     val supportTeams = aboutLCKState?.supportTeam ?: emptyList()
 
     val date = aboutLCKState?.date
+
+    val datePickerState = rememberDatePickerState()
+
+
+    if (showCalender) {
+        DatePickerDialog(
+            onDismissRequest = { showCalender = false },
+            confirmButton = {
+                TextButton(onClick = {
+                    val selectedMillis = datePickerState.selectedDateMillis
+                    if (selectedMillis != null) {
+                        val formattedDate = formatMillisToDate(selectedMillis)
+                        onIntent(AboutLCKIntent.ChangeDate(formattedDate))
+                    }
+                    showCalender = false
+                }) {
+                    Text("OK")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showCalender = false }) {
+                    Text("Cancel")
+                }
+            }
+        ) {
+            DatePicker(state = datePickerState)
+        }
+    }
 
     Box(modifier = Modifier.fillMaxSize()) {
         Scaffold(
@@ -116,7 +151,7 @@ fun AboutLCKScreen(
                         modifier = Modifier.padding(top = 24.dp),
                         date = date.toString(),
                         showDatePicker = {
-                            showCalender.value = true
+                            showCalender = true
                         }
                     )
                 }

--- a/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/AboutLCKScreen.kt
+++ b/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/AboutLCKScreen.kt
@@ -119,6 +119,7 @@ fun AboutLCKScreen(
     val aboutLCKState = state as? AboutLCKUiState.AboutLCK
     val ranking = aboutLCKState?.ranking?.groups?.firstOrNull()?.teams ?: emptyList()
     val matches = aboutLCKState?.match?.matches ?: emptyList()
+
     var showCalender by remember { mutableStateOf(false) }
     val supportTeams = aboutLCKState?.supportTeam ?: emptyList()
 

--- a/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/AboutLCKScreen.kt
+++ b/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/AboutLCKScreen.kt
@@ -64,22 +64,48 @@ fun AboutLCKRoute(
         }
     }
 
-    println(aboutLCK)
-    if(aboutLCK == null){
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(EveryLoLTheme.color.newBg),
-            contentAlignment = Alignment.Center
-        ) {
-            CircularProgressIndicator(color = EveryLoLTheme.color.grayScale200)
+    when(uiState){
+        is AboutLCKUiState.Loading -> {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(EveryLoLTheme.color.newBg),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator(color = EveryLoLTheme.color.grayScale200)
+            }
         }
-    }else {
-        AboutLCKScreen(
-            state = uiState,
-            snackbarHostState = snackbarHostState,
-            onIntent = viewModel::onIntent
-        )
+        is AboutLCKUiState.AboutLCK -> {
+            AboutLCKScreen(
+                state = uiState,
+                snackbarHostState = snackbarHostState,
+                onIntent = viewModel::onIntent
+            )
+        }
+        is AboutLCKUiState.Match -> {
+            AboutLCKMatchScreen(
+                state = uiState as AboutLCKUiState.Match,
+                snackbarHostState = snackbarHostState,
+                onBackClick = { viewModel.onIntent(AboutLCKIntent.LoadInitial) },
+                onIntent = viewModel::onIntent
+            )
+        }
+        is AboutLCKUiState.Team -> {
+            AboutLCKTeamScreen(
+                state = uiState as AboutLCKUiState.Team,
+                snackbarHostState = snackbarHostState,
+                onBackClick = { viewModel.onIntent(AboutLCKIntent.LoadInitial) },
+                onIntent = viewModel::onIntent
+            )
+        }
+        is AboutLCKUiState.Player -> {
+            AboutLCKPlayerScreen(
+                state = uiState as AboutLCKUiState.Player,
+                snackbarHostState = snackbarHostState,
+                onBackClick = { viewModel.onIntent(AboutLCKIntent.LoadInitial) },
+                onIntent = viewModel::onIntent
+            )
+        }
     }
 }
 
@@ -161,7 +187,11 @@ fun AboutLCKScreen(
                             verticalArrangement = Arrangement.spacedBy(8.dp)
                         ) {
                             AboutLCKMatchCard(
-                                item = matchItem
+                                item = matchItem,
+                                onClick = {
+                                    onIntent(AboutLCKIntent.Match(matchItem.matchId, matchItem))
+                                    println("matchId: ${matchItem.matchId}")
+                                }
                             )
                         }
                     }

--- a/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/AboutLCKScreen.kt
+++ b/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/AboutLCKScreen.kt
@@ -38,6 +38,9 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import every.lol.com.core.common.formatMillisToDate
 import every.lol.com.core.designsystem.component.EverylolTopAppBar
 import every.lol.com.core.designsystem.theme.EveryLoLTheme
+import every.lol.com.core.model.MatchCardModel
+import every.lol.com.core.model.MatchStatus
+import every.lol.com.core.model.aboutlck.match.MatchDetail
 import every.lol.com.core.ui.component.LckRankingSection
 import every.lol.com.core.ui.ext.everylolDefault
 import every.lol.com.feature.aboutlck.component.AboutLCKMatchCard
@@ -118,7 +121,7 @@ fun AboutLCKScreen(
 
     val aboutLCKState = state as? AboutLCKUiState.AboutLCK
     val ranking = aboutLCKState?.ranking?.groups?.firstOrNull()?.teams ?: emptyList()
-    val matches = aboutLCKState?.match?.matches ?: emptyList()
+    val matches = aboutLCKState?.match?.matches?.map { it.toMatchCardModel() } ?: emptyList()
 
     var showCalender by remember { mutableStateOf(false) }
     val supportTeams = aboutLCKState?.supportTeam ?: emptyList()
@@ -190,8 +193,7 @@ fun AboutLCKScreen(
                             AboutLCKMatchCard(
                                 item = matchItem,
                                 onClick = {
-                                    onIntent(AboutLCKIntent.Match(matchItem.matchId, matchItem))
-                                    println("matchId: ${matchItem.matchId}")
+                                    onIntent(AboutLCKIntent.Match(matchItem.matchId.toInt(), matchItem))
                                 }
                             )
                         }
@@ -237,3 +239,21 @@ fun AboutLCKScreen(
         }
     }
 }
+
+private fun MatchDetail.toMatchCardModel(): MatchCardModel = MatchCardModel(
+    matchId = matchId.toLong(),
+    matchDate = matchDate,
+    matchStatus = MatchStatus.valueOf(matchStatus),
+    seasonName = seasonName,
+    groupName = groupName,
+    roundName = roundName ?: "",
+    team1Id = team1.teamId,
+    team1Name = team1.teamName,
+    team2Id = team2.teamId,
+    team2Name = team2.teamName,
+    actualWinnerTeamName = when {
+        team1.winner -> team1.teamName
+        team2.winner -> team2.teamName
+        else -> null
+    }
+)

--- a/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/AboutLCKScreen.kt
+++ b/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/AboutLCKScreen.kt
@@ -40,7 +40,6 @@ import every.lol.com.feature.aboutlck.model.AboutLCKIntent
 import every.lol.com.feature.aboutlck.model.AboutLCKUiState
 import moe.tlaster.precompose.koin.koinViewModel
 
-
 @Composable
 fun AboutLCKRoute(
     viewModel: AboutLCKViewModel = koinViewModel(AboutLCKViewModel ::class)
@@ -68,7 +67,6 @@ fun AboutLCKRoute(
         ) {
             CircularProgressIndicator(color = EveryLoLTheme.color.grayScale200)
         }
-
     }else {
         AboutLCKScreen(
             state = uiState,
@@ -90,6 +88,8 @@ fun AboutLCKScreen(
     val matches = aboutLCKState?.match?.matches ?: emptyList()
     var showCalender =  remember { mutableStateOf(false) }
     val supportTeams = aboutLCKState?.supportTeam ?: emptyList()
+
+    val date = aboutLCKState?.date
 
     Box(modifier = Modifier.fillMaxSize()) {
         Scaffold(
@@ -114,7 +114,7 @@ fun AboutLCKScreen(
                 item {
                     DateSelectSection(
                         modifier = Modifier.padding(top = 24.dp),
-                        date = "2026-04-05",
+                        date = date.toString(),
                         showDatePicker = {
                             showCalender.value = true
                         }

--- a/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/AboutLCKTeamPlayerScreen.kt
+++ b/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/AboutLCKTeamPlayerScreen.kt
@@ -1,0 +1,55 @@
+package every.lol.com.feature.aboutlck
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import every.lol.com.core.designsystem.component.EverylolTopAppBar
+import every.lol.com.core.designsystem.theme.EveryLoLTheme
+import every.lol.com.core.ui.ext.everylolDefault
+import every.lol.com.feature.aboutlck.model.AboutLCKIntent
+import every.lol.com.feature.aboutlck.model.AboutLCKUiState
+
+@Composable
+fun AboutLCKTeamPlayerScreen(
+    state: AboutLCKUiState,
+    snackbarHostState: SnackbarHostState,
+    onIntent: (AboutLCKIntent) -> Unit
+) {
+
+    val aboutLCKState = state as? AboutLCKUiState.AboutLCK
+
+        Scaffold(
+            modifier = Modifier
+                .fillMaxSize()
+                .everylolDefault(EveryLoLTheme.color.newBg, false),
+            containerColor = Color.Transparent,
+            contentWindowInsets = WindowInsets(0, 0, 0, 0),
+            snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
+            topBar = {
+                EverylolTopAppBar(title = "About LCK")
+            }
+        ) { innerPadding ->
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(top = innerPadding.calculateTopPadding(), bottom = 0.dp)
+                    .padding(horizontal = 16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(20.dp)
+            ) {
+                item {
+
+                }
+            }
+        }
+    }

--- a/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/AboutLCKTeamScreen.kt
+++ b/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/AboutLCKTeamScreen.kt
@@ -36,7 +36,7 @@ fun AboutLCKTeamScreen(
             contentWindowInsets = WindowInsets(0, 0, 0, 0),
             snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
             topBar = {
-                EverylolTopAppBar(title = "About LCK")
+                EverylolTopAppBar(onBackClick = onBackClick, title = "About LCK")
             }
         ) { innerPadding ->
             LazyColumn(

--- a/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/AboutLCKTeamScreen.kt
+++ b/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/AboutLCKTeamScreen.kt
@@ -23,10 +23,10 @@ import every.lol.com.feature.aboutlck.model.AboutLCKUiState
 fun AboutLCKTeamScreen(
     state: AboutLCKUiState,
     snackbarHostState: SnackbarHostState,
+    onBackClick: () -> Unit,
     onIntent: (AboutLCKIntent) -> Unit
 ) {
 
-    val aboutLCKState = state as? AboutLCKUiState.AboutLCK
 
         Scaffold(
             modifier = Modifier

--- a/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/AboutLCKTeamScreen.kt
+++ b/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/AboutLCKTeamScreen.kt
@@ -1,0 +1,55 @@
+package every.lol.com.feature.aboutlck
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import every.lol.com.core.designsystem.component.EverylolTopAppBar
+import every.lol.com.core.designsystem.theme.EveryLoLTheme
+import every.lol.com.core.ui.ext.everylolDefault
+import every.lol.com.feature.aboutlck.model.AboutLCKIntent
+import every.lol.com.feature.aboutlck.model.AboutLCKUiState
+
+@Composable
+fun AboutLCKTeamScreen(
+    state: AboutLCKUiState,
+    snackbarHostState: SnackbarHostState,
+    onIntent: (AboutLCKIntent) -> Unit
+) {
+
+    val aboutLCKState = state as? AboutLCKUiState.AboutLCK
+
+        Scaffold(
+            modifier = Modifier
+                .fillMaxSize()
+                .everylolDefault(EveryLoLTheme.color.newBg, false),
+            containerColor = Color.Transparent,
+            contentWindowInsets = WindowInsets(0, 0, 0, 0),
+            snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
+            topBar = {
+                EverylolTopAppBar(title = "About LCK")
+            }
+        ) { innerPadding ->
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(top = innerPadding.calculateTopPadding(), bottom = 0.dp)
+                    .padding(horizontal = 16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(20.dp)
+            ) {
+                item {
+
+                }
+            }
+        }
+    }

--- a/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/AboutLCKViewModel.kt
+++ b/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/AboutLCKViewModel.kt
@@ -1,11 +1,13 @@
 package every.lol.com.feature.aboutlck
 
 import every.lol.com.core.domain.usecase.GetHomeRankingUseCase
+import every.lol.com.core.domain.usecase.GetMatchVoteRateUseCase
+import every.lol.com.core.domain.usecase.GetMatchesUseCase
 import every.lol.com.core.domain.usecase.GetSupportTeamUseCase
 import every.lol.com.core.domain.usecase.aboutlck.GetAboutLCKMatchUseCase
+import every.lol.com.core.model.MatchCardModel
 import every.lol.com.core.model.Ranking
 import every.lol.com.core.model.aboutlck.match.AboutLCKMatch
-import every.lol.com.core.model.aboutlck.match.MatchDetail
 import every.lol.com.feature.aboutlck.model.AboutLCKIntent
 import every.lol.com.feature.aboutlck.model.AboutLCKUiState
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -29,7 +31,9 @@ sealed interface AboutLCKEvent{
 class AboutLCKViewModel(
     private val getAboutLCKMatchUseCase: GetAboutLCKMatchUseCase,
     private val getHomeRankingUseCase: GetHomeRankingUseCase,
-    private val getSupportTeamUseCase: GetSupportTeamUseCase
+    private val getSupportTeamUseCase: GetSupportTeamUseCase,
+    private val getMatchesUseCase: GetMatchesUseCase,
+    private val getMatchVoteRateUseCase: GetMatchVoteRateUseCase
     ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<AboutLCKUiState>(AboutLCKUiState.Loading)
@@ -38,6 +42,15 @@ class AboutLCKViewModel(
     private val _event = MutableSharedFlow<AboutLCKEvent>(replay = 0)
     val event = _event.asSharedFlow()
 
+    private var cachedMatches: List<MatchCardModel>? = null
+    private var cachedExpandedIndex: Int = -1
+    private var isFetching = false
+
+    private var cachedRanking: Ranking? = null
+    private var cachedMatch: AboutLCKMatch? = null
+    private var cachedSupportTeam: List<Int>? = null
+    private var cachedDate: String? = null
+    private var isInitialLoaded = false
 
     init {
         onIntent(AboutLCKIntent.LoadInitial)
@@ -51,12 +64,6 @@ class AboutLCKViewModel(
             else -> {}
         }
     }
-
-    private var cachedRanking: Ranking? = null
-    private var cachedMatch: AboutLCKMatch? = null
-    private var cachedSupportTeam: List<Int>? = null
-    private var cachedDate: String? = null
-    private var isInitialLoaded = false
 
     private fun loadInitial() {
 
@@ -78,6 +85,7 @@ class AboutLCKViewModel(
         isInitialLoaded = true
         loadDate()
         loadRanking()
+        loadMatches()
     }
 
     private fun loadDate(date: String? = null) {
@@ -100,7 +108,7 @@ class AboutLCKViewModel(
         getMatch(targetDate)
     }
 
-    private fun loadMatchPage(matchId: Int, matchData: MatchDetail) {
+    private fun loadMatchPage(matchId: Int, matchData: MatchCardModel) {
         _uiState.update {
             AboutLCKUiState.Match(
                 matchId = matchId,
@@ -132,6 +140,61 @@ class AboutLCKViewModel(
         }
     }
 
+    private fun loadMatches(isRefresh: Boolean = false) {
+        if (isFetching) return
+
+        if (!isRefresh && cachedMatches != null) {
+            updateAboutLCKState { it.copy(isLoading = false) }
+            return
+        }
+
+        isFetching = true
+        updateLoading(true)
+
+        viewModelScope.launch {
+            getMatchesUseCase().onSuccess { matchInfo ->
+                val matchCards = matchInfo.matchInfo.map { match ->
+                    val voteRate = getMatchVoteRateUseCase(match.matchId).getOrNull()
+                    MatchCardModel(
+                        matchId = match.matchId,
+                        matchDate = match.matchDate,
+                        matchStatus = match.matchStatus,
+                        seasonName = match.seasonName,
+                        groupName = match.groupName,
+                        roundName = match.roundName,
+                        team1Id = match.team1.teamId,
+                        team1Name = match.team1.teamName,
+                        team2Id = match.team2.teamId,
+                        team2Name = match.team2.teamName,
+                        team1VoteRate = voteRate?.team1?.voteRate ?: 0.0,
+                        team2VoteRate = voteRate?.team2?.voteRate ?: 0.0,
+                        totalVoteCount = voteRate?.totalVoteCount ?: 0,
+                        predictedWinnerTeamName = when {
+                            (voteRate?.team1?.voteRate ?: 0.0) > (voteRate?.team2?.voteRate ?: 0.0) -> match.team1.teamName
+                            (voteRate?.team2?.voteRate ?: 0.0) > (voteRate?.team1?.voteRate ?: 0.0) -> match.team2.teamName
+                            else -> null
+                        },
+                        actualWinnerTeamName = when {
+                            match.team1.winner -> match.team1.teamName
+                            match.team2.winner -> match.team2.teamName
+                            else -> null
+                        }
+                    )
+                }
+
+                cachedMatches = matchCards
+                cachedExpandedIndex = if (matchCards.isNotEmpty()) 0 else -1
+
+                updateAboutLCKState { it.copy(isLoading = false) }
+                isFetching = false
+            }.onFailure {
+                isFetching = false
+                updateLoading(false)
+            }
+        }
+    }
+
+
     private fun loadRanking() {
         viewModelScope.launch {
             getHomeRankingUseCase().onSuccess { result ->
@@ -158,6 +221,16 @@ class AboutLCKViewModel(
             }
         }
 
+    }
+    private fun updateAboutLCKState(transform: (AboutLCKUiState.AboutLCK) -> AboutLCKUiState.AboutLCK) {
+        _uiState.update { state ->
+            val currentState = state as? AboutLCKUiState.AboutLCK ?: AboutLCKUiState.AboutLCK()
+            transform(currentState)
+        }
+    }
+
+    private fun updateLoading(isLoading: Boolean) {
+        updateAboutLCKState { it.copy(isLoading = isLoading) }
     }
 
 }

--- a/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/AboutLCKViewModel.kt
+++ b/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/AboutLCKViewModel.kt
@@ -1,5 +1,6 @@
 package every.lol.com.feature.aboutlck
 
+import every.lol.com.core.common.formatMillisToDate
 import every.lol.com.core.domain.usecase.GetHomeRankingUseCase
 import every.lol.com.core.domain.usecase.GetMatchVoteRateUseCase
 import every.lol.com.core.domain.usecase.GetMatchesUseCase
@@ -16,12 +17,9 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toLocalDateTime
 import moe.tlaster.precompose.viewmodel.ViewModel
 import moe.tlaster.precompose.viewmodel.viewModelScope
 import kotlin.time.Clock
-import kotlin.time.Instant
 
 sealed interface AboutLCKEvent{
     data class ShowToast(val message: String): AboutLCKEvent
@@ -59,9 +57,11 @@ class AboutLCKViewModel(
     fun onIntent(intent: AboutLCKIntent) {
         when (intent) {
             AboutLCKIntent.LoadInitial -> loadInitial()
+            AboutLCKIntent.RefreshHome -> loadMatches(isRefresh = true)
             is AboutLCKIntent.Match -> loadMatchPage(intent.matchId, intent.matchData)
             is AboutLCKIntent.ChangeDate -> loadDate(intent.date)
-            else -> {}
+            is AboutLCKIntent.Team -> {} // TODO: Team 화면 전환 로직 연결
+            is AboutLCKIntent.Player -> {} // TODO: Player 화면 전환 로직 연결
         }
     }
 
@@ -89,13 +89,7 @@ class AboutLCKViewModel(
     }
 
     private fun loadDate(date: String? = null) {
-        val targetDate = if (date != null) {
-            date
-        } else {
-            val nowMs = Clock.System.now().toEpochMilliseconds()
-            val instant = Instant.fromEpochMilliseconds(nowMs)
-            instant.toLocalDateTime(TimeZone.currentSystemDefault()).date.toString()
-        }
+        val targetDate = date ?: formatMillisToDate(Clock.System.now().toEpochMilliseconds())
         cachedDate = targetDate
 
         _uiState.update { state ->

--- a/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/AboutLCKViewModel.kt
+++ b/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/AboutLCKViewModel.kt
@@ -3,6 +3,9 @@ package every.lol.com.feature.aboutlck
 import every.lol.com.core.domain.usecase.GetHomeRankingUseCase
 import every.lol.com.core.domain.usecase.GetSupportTeamUseCase
 import every.lol.com.core.domain.usecase.aboutlck.GetAboutLCKMatchUseCase
+import every.lol.com.core.model.Ranking
+import every.lol.com.core.model.aboutlck.match.AboutLCKMatch
+import every.lol.com.core.model.aboutlck.match.MatchDetail
 import every.lol.com.feature.aboutlck.model.AboutLCKIntent
 import every.lol.com.feature.aboutlck.model.AboutLCKUiState
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -43,18 +46,36 @@ class AboutLCKViewModel(
     fun onIntent(intent: AboutLCKIntent) {
         when (intent) {
             AboutLCKIntent.LoadInitial -> loadInitial()
+            is AboutLCKIntent.Match -> loadMatchPage(intent.matchId, intent.matchData)
             is AboutLCKIntent.ChangeDate -> loadDate(intent.date)
             else -> {}
         }
     }
 
+    private var cachedRanking: Ranking? = null
+    private var cachedMatch: AboutLCKMatch? = null
+    private var cachedSupportTeam: List<Int>? = null
+    private var cachedDate: String? = null
     private var isInitialLoaded = false
 
     private fun loadInitial() {
-        if (isInitialLoaded) return
-        isInitialLoaded = true
 
-        println("loadInitial")
+        _uiState.update { state ->
+            if (state is AboutLCKUiState.AboutLCK) {
+                state
+            } else {
+                AboutLCKUiState.AboutLCK(
+                    ranking = cachedRanking,
+                    match = cachedMatch,
+                    supportTeam = cachedSupportTeam ?: emptyList(),
+                    date = cachedDate ?: ""
+                )
+            }
+        }
+
+        if (isInitialLoaded) return
+
+        isInitialLoaded = true
         loadDate()
         loadRanking()
     }
@@ -67,6 +88,7 @@ class AboutLCKViewModel(
             val instant = Instant.fromEpochMilliseconds(nowMs)
             instant.toLocalDateTime(TimeZone.currentSystemDefault()).date.toString()
         }
+        cachedDate = targetDate
 
         _uiState.update { state ->
             val currentState = state as? AboutLCKUiState.AboutLCK ?: AboutLCKUiState.AboutLCK()
@@ -78,9 +100,19 @@ class AboutLCKViewModel(
         getMatch(targetDate)
     }
 
+    private fun loadMatchPage(matchId: Int, matchData: MatchDetail) {
+        _uiState.update {
+            AboutLCKUiState.Match(
+                matchId = matchId,
+                matchData = matchData,
+                isLoading = false
+            )
+        }
+    }
     private fun getMatch(date:String){
         viewModelScope.launch {
             getAboutLCKMatchUseCase(date).onSuccess { result ->
+                cachedMatch = result
                 _uiState.update { state ->
                     val currentState = state as? AboutLCKUiState.AboutLCK ?:AboutLCKUiState.AboutLCK()
                     currentState.copy(
@@ -104,6 +136,8 @@ class AboutLCKViewModel(
         viewModelScope.launch {
             getHomeRankingUseCase().onSuccess { result ->
                 getSupportTeamUseCase().onSuccess { supportTeam ->
+                    cachedRanking = result
+                    cachedSupportTeam = supportTeam
                     _uiState.update { state ->
                         val currentState = state as? AboutLCKUiState.AboutLCK ?:AboutLCKUiState.AboutLCK()
                         currentState.copy(

--- a/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/AboutLCKViewModel.kt
+++ b/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/AboutLCKViewModel.kt
@@ -11,8 +11,12 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
 import moe.tlaster.precompose.viewmodel.ViewModel
 import moe.tlaster.precompose.viewmodel.viewModelScope
+import kotlin.time.Clock
+import kotlin.time.Instant
 
 sealed interface AboutLCKEvent{
     data class ShowToast(val message: String): AboutLCKEvent
@@ -39,6 +43,7 @@ class AboutLCKViewModel(
     fun onIntent(intent: AboutLCKIntent) {
         when (intent) {
             AboutLCKIntent.LoadInitial -> loadInitial()
+            is AboutLCKIntent.ChangeDate -> loadDate(intent.date)
             else -> {}
         }
     }
@@ -50,8 +55,27 @@ class AboutLCKViewModel(
         isInitialLoaded = true
 
         println("loadInitial")
-        getMatch("2026-04-05")
+        loadDate()
         loadRanking()
+    }
+
+    private fun loadDate(date: String? = null) {
+        val targetDate = if (date != null) {
+            date
+        } else {
+            val nowMs = Clock.System.now().toEpochMilliseconds()
+            val instant = Instant.fromEpochMilliseconds(nowMs)
+            instant.toLocalDateTime(TimeZone.currentSystemDefault()).date.toString()
+        }
+
+        _uiState.update { state ->
+            val currentState = state as? AboutLCKUiState.AboutLCK ?: AboutLCKUiState.AboutLCK()
+            currentState.copy(
+                isLoading = true,
+                date = targetDate
+            )
+        }
+        getMatch(targetDate)
     }
 
     private fun getMatch(date:String){

--- a/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/component/AboutLCKMatchCard.kt
+++ b/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/component/AboutLCKMatchCard.kt
@@ -31,14 +31,14 @@ fun AboutLCKMatchCard (
     modifier = modifier
         .fillMaxWidth()
         .clip(RoundedCornerShape(8.dp))
-        .clickable(
-            onClick = onClick
-        )
         .background(EveryLoLTheme.color.newBg)
         .border(
             width = 1.dp,
             color = EveryLoLTheme.color.grayScale900,
             shape = RoundedCornerShape(8.dp)
+        )
+        .clickable(
+            onClick = onClick
         )
         .padding(20.dp, 28.dp)
     ) {

--- a/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/component/AboutLCKMatchCard.kt
+++ b/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/component/AboutLCKMatchCard.kt
@@ -2,6 +2,7 @@ package every.lol.com.feature.aboutlck.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -23,12 +24,16 @@ import every.lol.com.core.ui.component.getTeamColor
 @Composable
 fun AboutLCKMatchCard (
     item: MatchDetail,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit = {}
 ) {
     Box(
     modifier = modifier
         .fillMaxWidth()
         .clip(RoundedCornerShape(8.dp))
+        .clickable(
+            onClick = onClick
+        )
         .background(EveryLoLTheme.color.newBg)
         .border(
             width = 1.dp,

--- a/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/component/AboutLCKMatchCard.kt
+++ b/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/component/AboutLCKMatchCard.kt
@@ -17,13 +17,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import every.lol.com.core.designsystem.theme.EveryLoLTheme
-import every.lol.com.core.model.aboutlck.match.MatchDetail
+import every.lol.com.core.model.MatchCardModel
 import every.lol.com.core.ui.component.CardTag
 import every.lol.com.core.ui.component.getTeamColor
 
 @Composable
 fun AboutLCKMatchCard (
-    item: MatchDetail,
+    item: MatchCardModel,
     modifier: Modifier = Modifier,
     onClick: () -> Unit = {}
 ) {
@@ -67,13 +67,13 @@ fun AboutLCKMatchCard (
                 Spacer(Modifier.weight(1f))
                 Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
                     CardTag(
-                        text = item.team1.teamName,
-                        backgroundColor = getTeamColor(item.team1.teamName),
+                        text = item.team1Name,
+                        backgroundColor = getTeamColor(item.team1Name),
                         textColor = EveryLoLTheme.color.black900
                     )
                     CardTag(
-                        text = item.team2.teamName,
-                        backgroundColor = getTeamColor(item.team2.teamName),
+                        text = item.team2Name,
+                        backgroundColor = getTeamColor(item.team2Name),
                         textColor = EveryLoLTheme.color.black900
                     )
                 }

--- a/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/model/AboutLCKUiModel.kt
+++ b/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/model/AboutLCKUiModel.kt
@@ -15,6 +15,21 @@ sealed interface AboutLCKUiState {
         val supportTeam: List<Int> = emptyList(),
         val match: AboutLCKMatch?= null
         ) : AboutLCKUiState
+
+    data class Match(
+        val matchId: Int,
+        val isLoading: Boolean=false
+    ): AboutLCKUiState
+
+    data class Team(
+        val teamId: Int,
+        val isLoading: Boolean=false
+    ): AboutLCKUiState
+
+    data class Player(
+        val playerId: Int,
+        val isLoading: Boolean=false
+    ): AboutLCKUiState
 }
 
 sealed interface AboutLCKIntent {

--- a/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/model/AboutLCKUiModel.kt
+++ b/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/model/AboutLCKUiModel.kt
@@ -3,6 +3,7 @@ package every.lol.com.feature.aboutlck.model
 import androidx.compose.runtime.Immutable
 import every.lol.com.core.model.Ranking
 import every.lol.com.core.model.aboutlck.match.AboutLCKMatch
+import every.lol.com.core.model.aboutlck.match.MatchDetail
 
 @Immutable
 sealed interface AboutLCKUiState {
@@ -18,6 +19,7 @@ sealed interface AboutLCKUiState {
 
     data class Match(
         val matchId: Int,
+        val matchData: MatchDetail,
         val isLoading: Boolean=false
     ): AboutLCKUiState
 
@@ -36,4 +38,7 @@ sealed interface AboutLCKIntent {
     data object LoadInitial : AboutLCKIntent
     data object RefreshHome : AboutLCKIntent
     data class ChangeDate(val date: String) : AboutLCKIntent
+    data class Match(val matchId: Int, val matchData: MatchDetail) : AboutLCKIntent
+    data class Team(val teamId: Int) : AboutLCKIntent
+    data class Player(val playerId: Int) : AboutLCKIntent
 }

--- a/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/model/AboutLCKUiModel.kt
+++ b/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/model/AboutLCKUiModel.kt
@@ -1,9 +1,9 @@
 package every.lol.com.feature.aboutlck.model
 
 import androidx.compose.runtime.Immutable
+import every.lol.com.core.model.MatchCardModel
 import every.lol.com.core.model.Ranking
 import every.lol.com.core.model.aboutlck.match.AboutLCKMatch
-import every.lol.com.core.model.aboutlck.match.MatchDetail
 
 @Immutable
 sealed interface AboutLCKUiState {
@@ -19,7 +19,7 @@ sealed interface AboutLCKUiState {
 
     data class Match(
         val matchId: Int,
-        val matchData: MatchDetail,
+        val matchData: MatchCardModel,
         val isLoading: Boolean=false
     ): AboutLCKUiState
 
@@ -38,7 +38,7 @@ sealed interface AboutLCKIntent {
     data object LoadInitial : AboutLCKIntent
     data object RefreshHome : AboutLCKIntent
     data class ChangeDate(val date: String) : AboutLCKIntent
-    data class Match(val matchId: Int, val matchData: MatchDetail) : AboutLCKIntent
+    data class Match(val matchId: Int, val matchData: MatchCardModel) : AboutLCKIntent
     data class Team(val teamId: Int) : AboutLCKIntent
     data class Player(val playerId: Int) : AboutLCKIntent
 }

--- a/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/model/AboutLCKUiModel.kt
+++ b/feature/aboutlck/src/commonMain/kotlin/every/lol/com/feature/aboutlck/model/AboutLCKUiModel.kt
@@ -9,6 +9,7 @@ sealed interface AboutLCKUiState {
     data object Loading : AboutLCKUiState
 
     data class AboutLCK(
+        val date: String?=null,
         val isLoading: Boolean = false,
         val ranking: Ranking?= null,
         val supportTeam: List<Int> = emptyList(),
@@ -19,4 +20,5 @@ sealed interface AboutLCKUiState {
 sealed interface AboutLCKIntent {
     data object LoadInitial : AboutLCKIntent
     data object RefreshHome : AboutLCKIntent
+    data class ChangeDate(val date: String) : AboutLCKIntent
 }


### PR DESCRIPTION
- closed #97 

## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * About LCK에서 날짜를 선택해 해당 날짜의 경기 정보를 조회할 수 있습니다.
  * 경기 카드를 선택하면 경기 상세 화면으로 이동할 수 있습니다.
  * 종료된 경기에서 팀별 승부예측 결과와 예측 승자 정보를 확인할 수 있습니다.
  * 경기·팀·선수 상세 화면의 기본 탐색 구조를 추가했습니다.

* **개선 사항**
  * 경기 목록에 팀별 투표 비율과 승패 정보가 표시됩니다.
  * 데이터가 없는 순위 화면에서도 레이아웃이 올바르게 적용됩니다.
  * 날짜가 UTC 기준의 일관된 형식으로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->