### PR TITLE
[Fix/#103] QA 반영

### DIFF
--- a/core/data/src/commonMain/kotlin/every/lol/com/core/data/repository/AuthRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/every/lol/com/core/data/repository/AuthRepositoryImpl.kt
@@ -20,7 +20,7 @@ class AuthRepositoryImpl(
 ): AuthRepository {
 
     override suspend fun login(kakaoUserId: String): Result<Unit> =
-        remote.login(KakaoRequest("20040611"))
+        remote.login(KakaoRequest(kakaoUserId))
             .toResult()
             .mapCatching { dto ->
                 local.saveUserId(kakaoUserId)
@@ -36,7 +36,7 @@ class AuthRepositoryImpl(
         val signupRequest = SignupRequest(
             profileImage = request.profileImage,
             signupUserData = SignupUserData(
-                kakaoUserId = "20040611",
+                kakaoUserId = request.kakaoUserId,
                 nickName = request.nickname,
                 role = "ROLE_USER",
                 tier = "bronze",

--- a/core/data/src/commonMain/kotlin/every/lol/com/core/data/repository/MyPageRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/every/lol/com/core/data/repository/MyPageRepositoryImpl.kt
@@ -36,9 +36,7 @@ class MyPageRepositoryImpl(
     }
 
 
-    override suspend fun patchProfile(nickname: String?, profileImage: ByteArray?): Result<Unit> {
-        val isDefaultImage = if (profileImage == null) true else false
-
+    override suspend fun patchProfile(nickname: String?, profileImage: ByteArray?, isDefaultImage: Boolean): Result<Unit> {
         return remote.patchProfile(
             request = PatchProfileRequest(
                 profileImage = profileImage,

--- a/core/domain/src/commonMain/kotlin/every/lol/com/core/domain/repository/MyPagesRepository.kt
+++ b/core/domain/src/commonMain/kotlin/every/lol/com/core/domain/repository/MyPagesRepository.kt
@@ -9,7 +9,7 @@ import every.lol.com.core.model.mypage.MypagePredictions
 
 interface MyPagesRepository {
     suspend fun getProfile(): Result<UserInform>
-    suspend fun patchProfile(nickname: String?, profileImage: ByteArray?): Result<Unit>
+    suspend fun patchProfile(nickname: String?, profileImage: ByteArray?, isDefaultImage: Boolean = false): Result<Unit>
     suspend fun patchMyTeam(teamIds: List<Int>): Result<Unit>
     suspend fun getPosts(page: Int): Result<Posts>
     suspend fun getComments(page: Int): Result<Comments>

--- a/core/domain/src/commonMain/kotlin/every/lol/com/core/domain/usecase/PatchProfileUseCase.kt
+++ b/core/domain/src/commonMain/kotlin/every/lol/com/core/domain/usecase/PatchProfileUseCase.kt
@@ -6,6 +6,6 @@ import every.lol.com.core.domain.repository.MyPagesRepository
 class PatchProfileUseCase(
     private val myPagesRepository: MyPagesRepository
 ) {
-    suspend operator fun invoke(nickname: String?, profileImage: ByteArray?): Result<Unit> =
-        myPagesRepository.patchProfile(nickname, profileImage)
+    suspend operator fun invoke(nickname: String?, profileImage: ByteArray?, isDefaultImage: Boolean = false): Result<Unit> =
+        myPagesRepository.patchProfile(nickname, profileImage, isDefaultImage)
 }

--- a/core/navigation/src/commonMain/kotlin/every/lol/com/core/navigation/MainTab.kt
+++ b/core/navigation/src/commonMain/kotlin/every/lol/com/core/navigation/MainTab.kt
@@ -1,6 +1,8 @@
 package every.lol.com.core.navigation
 
 import everylol.core.navigation.generated.resources.Res
+import everylol.core.navigation.generated.resources.ic_aboutlck_active
+import everylol.core.navigation.generated.resources.ic_aboutlck_none
 import everylol.core.navigation.generated.resources.ic_community_active
 import everylol.core.navigation.generated.resources.ic_community_none
 import everylol.core.navigation.generated.resources.ic_home_active
@@ -17,6 +19,6 @@ enum class MainTab (
 ){
     Home(Route.Home, "홈", Res.drawable.ic_home_active, Res.drawable.ic_home_none),
     Matches(Route.Matches, "오늘의 매치",Res.drawable.ic_matches_active, Res.drawable.ic_matches_none),
-    //AboutLCK(Route.AboutLCK, "LCK 대해", Res.drawable.ic_aboutlck_active, Res.drawable.ic_aboutlck_none),
+    AboutLCK(Route.AboutLCK, "LCK 대해", Res.drawable.ic_aboutlck_active, Res.drawable.ic_aboutlck_none),
     Community(Route.Community, "커뮤니티", Res.drawable.ic_community_active, Res.drawable.ic_community_none)
 }

--- a/core/ui/src/commonMain/kotlin/every/lol/com/core/ui/component/LCKRankingSection.kt
+++ b/core/ui/src/commonMain/kotlin/every/lol/com/core/ui/component/LCKRankingSection.kt
@@ -92,8 +92,10 @@ fun LckRankingSection(
                 )
             }
             top3.forEach { team ->
+                val isMyTeam = supportTeams.contains(fromTeamName(team.teamName).id)
                 TopRankCard(
                     team = team,
+                    isFavorite = isMyTeam,
                     onClick = onTeamClick,
                     //cardBackground = cardBackground
                 )
@@ -173,6 +175,7 @@ private fun FavoriteRankCard(
 @Composable
 private fun TopRankCard(
     team: RankingTeam,
+    isFavorite: Boolean = false,
     onClick: (Long) -> Unit
 ) {
 
@@ -201,7 +204,8 @@ private fun TopRankCard(
         shape = RoundedCornerShape(4.dp),
         colors = CardDefaults.cardColors(
             containerColor = EveryLoLTheme.color.grayScale1000
-        )
+        ),
+        border = if (isFavorite) BorderStroke(1.dp, getTeamColor(team.teamName)) else null
     ) {
         Box(
             modifier = Modifier

--- a/core/ui/src/commonMain/kotlin/every/lol/com/core/ui/component/NicknameSection.kt
+++ b/core/ui/src/commonMain/kotlin/every/lol/com/core/ui/component/NicknameSection.kt
@@ -96,31 +96,38 @@ private fun NicknameValidationGroup(
 
     val isEmpty = nickName.isEmpty()
 
-    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+    val validations = buildList {
         if (!isEmpty) {
-            NicknameValidation(
-                status = if (!isChanged) 0 else if (isDuplicateChecked) 1 else 2,
-                message = "중복된 닉네임은 사용할 수 없습니다"
+            add(
+                (if (!isChanged) 0 else if (isDuplicateChecked) 1 else 2) to
+                    "중복된 닉네임은 사용할 수 없습니다"
             )
         }
 
-        NicknameValidation(
-            status = when {
+        add(
+            (when {
                 !isChanged || isEmpty -> 0
                 isProperLength -> 1
                 else -> 2
-            },
-            message = "닉네임은 최대 10글자까지 입력 가능합니다"
+            }) to "닉네임은 최대 10글자까지 입력 가능합니다"
         )
 
-        NicknameValidation(
-            status = when {
+        add(
+            (when {
                 !isChanged || isEmpty -> 0
                 isNoSpace -> 1
                 else -> 2
-            },
-            message = "닉네임 사이에는 공백을 입력할 수 없습니다"
+            }) to "닉네임 사이에는 공백을 입력할 수 없습니다"
         )
+    }
+
+    val hasError = validations.any { (status, _) -> status == 2 }
+    val visibleValidations = if (hasError) validations.filter { (status, _) -> status == 2 } else validations
+
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        visibleValidations.forEach { (status, message) ->
+            NicknameValidation(status = status, message = message)
+        }
     }
 }
 

--- a/core/ui/src/commonMain/kotlin/every/lol/com/core/ui/component/NicknameSection.kt
+++ b/core/ui/src/commonMain/kotlin/every/lol/com/core/ui/component/NicknameSection.kt
@@ -46,7 +46,7 @@ fun NicknameSection(
     val textFieldStatus = when {
         !isNotEmpty -> 0
         isAllValid -> 1
-        isProfileEdit  && !isChanged -> 2
+        isChanged -> 2
         else -> 3
     }
 

--- a/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/CommunityViewModel.kt
+++ b/feature/community/src/commonMain/kotlin/every/lol/com/feature/community/CommunityViewModel.kt
@@ -115,6 +115,7 @@ class CommunityViewModel(
                 communityLoadJob?.cancel()
                 _uiState.value = CommunityUiState.Write(
                     postId = intent.postId,
+                    selectedTab = intent.tab,
                     title = intent.title,
                     content = intent.content,
                     selectedMedias = intent.medias,
@@ -296,6 +297,9 @@ class CommunityViewModel(
                 _uiState.update {
                     CommunityUiState.Write(
                         postId = postId,
+                        selectedTab = CommunityUiState.WriteTab.entries.find {
+                            it.displayName == post.postType
+                        } ?: CommunityUiState.WriteTab.TALK,
                         title = post.postTitle,
                         content = contentBuilder.toString(),
                         selectedMedias = mediaItems,

--- a/feature/matches/src/commonMain/kotlin/every/lol/com/feature/matches/LiveResultScreen.kt
+++ b/feature/matches/src/commonMain/kotlin/every/lol/com/feature/matches/LiveResultScreen.kt
@@ -151,7 +151,7 @@ fun LiveResultScreen(
                         .padding(top = 24.dp),
                     contentAlignment = Alignment.TopCenter
                 ) {
-                    CircularProgressIndicator()
+                    CircularProgressIndicator(color = EveryLoLTheme.color.grayScale200)
                 }
             }
 

--- a/feature/matches/src/commonMain/kotlin/every/lol/com/feature/matches/MatchesScreen.kt
+++ b/feature/matches/src/commonMain/kotlin/every/lol/com/feature/matches/MatchesScreen.kt
@@ -78,7 +78,7 @@ fun MatchesRoute(
                     .background(EveryLoLTheme.color.newBg),
                 contentAlignment = Alignment.Center
             ) {
-                CircularProgressIndicator()
+                CircularProgressIndicator(color = EveryLoLTheme.color.grayScale200)
             }
         }
 

--- a/feature/matches/src/commonMain/kotlin/every/lol/com/feature/matches/MatchesScreen.kt
+++ b/feature/matches/src/commonMain/kotlin/every/lol/com/feature/matches/MatchesScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -31,6 +32,8 @@ import every.lol.com.feature.matches.component.TopBar
 import every.lol.com.feature.matches.model.MatchIntent
 import every.lol.com.feature.matches.model.MatchUiState
 import moe.tlaster.precompose.koin.koinViewModel
+
+private const val CHZZK_LCK_URL = "https://chzzk.naver.com/9381e7d6816e6d915a44a13c0195b202"
 
 @Composable
 fun MatchesRoute(
@@ -96,6 +99,8 @@ fun MatchesScreen(
     onPredictionClick: (Long) -> Unit,
     onToggleMatchCard: (Int) -> Unit
 ) {
+    val uriHandler = LocalUriHandler.current
+
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -118,6 +123,9 @@ fun MatchesScreen(
                 if (isExpanded) {
                     DetailMatchCard(
                         item = item,
+                        onWatchClick = {
+                            uriHandler.openUri(CHZZK_LCK_URL)
+                        },
                         onPredictionClick = {
                             onPredictionClick(item.matchId)
                         },

--- a/feature/mypage/src/commonMain/kotlin/every/lol/com/feature/mypage/MypageViewModel.kt
+++ b/feature/mypage/src/commonMain/kotlin/every/lol/com/feature/mypage/MypageViewModel.kt
@@ -228,10 +228,12 @@ class MypageViewModel(
             return
         }
 
+        val isImageRemoved = current.profileImage == null && current.originalProfileImage != null
+
         val isImageChanged = when {
             current.profileImage is ByteArray -> true
             current.profileImage is String && !(current.profileImage as String).startsWith("http") -> true
-            current.profileImage == null && current.originalProfileImage != null -> true
+            isImageRemoved -> true
             else -> false
         }
 
@@ -257,7 +259,8 @@ class MypageViewModel(
 
                     patchProfileUseCase(
                         nickname = if (isNicknameChanged) current.nickName else null,
-                        profileImage = compressedImage
+                        profileImage = compressedImage,
+                        isDefaultImage = isImageRemoved
                     ).getOrThrow()
                 }
 


### PR DESCRIPTION
## Summary
- 닉네임 유효성 메시지 중복 노출 수정 (에러 시 해당 메시지만 표시)
- "경기보러가기" 클릭 시 치지직 LCK로 이동하도록 연결
- 게시글 수정 진입 시 원본 게시판 Type이 반영되도록 수정 (EditPost 인텐트의 tab이 버려지던 버그)
- 닉네임 유효성 실패 시 텍스트필드 테두리도 빨간색으로 표시
- 닉네임/응원팀만 수정해도 프로필 이미지가 기본으로 리셋되던 버그 수정
- LCK 순위 1~3등 구간에도 응원팀이면 테두리로 표시되도록 수정
- 로딩 인디케이터에서 Material3 기본 보라색이 잠깐 노출되던 문제 수정

Closes #103

## Test plan
- [x] `./gradlew compileDebugKotlinAndroid` 전체 컴파일 통과 확인
- [ ] 닉네임 입력 시 공백/길이 위반 등에서 에러 메시지만 보이고 텍스트필드 테두리가 빨간색인지 확인
- [ ] 마이페이지에서 닉네임/응원팀만 수정 후 저장 시 프로필 이미지가 유지되는지 확인
- [ ] 오늘의 매치에서 "경기 보러가기" 클릭 시 치지직 LCK로 이동하는지 확인
- [ ] 커뮤니티 게시글 수정 진입 시 원본 게시판 Type이 그대로 표시되는지 확인
- [ ] 홈 LCK 순위에서 응원팀이 1~3등일 때 테두리로 구분되는지 확인
- [ ] 각 화면 로딩 시 보라색 플리커 없이 회색 인디케이터만 보이는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * About LCK 탭이 다시 활성화되었습니다.
  * 경기 상세 화면에서 시청 버튼을 누르면 CHZZK 경기 중계 페이지가 열립니다.
  * LCK 랭킹에서 응원 팀이 시각적으로 표시됩니다.

* **개선 사항**
  * 로그인 및 회원가입 시 실제 카카오 사용자 ID가 사용됩니다.
  * 프로필 이미지 삭제 시 기본 이미지로 정상 처리됩니다.
  * 닉네임 검증 오류가 해당 항목만 표시되도록 개선되었습니다.
  * 게시글 수정 시 선택한 글쓰기 탭이 유지됩니다.
  * 로딩 화면의 색상 표시가 테마에 맞게 조정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->